### PR TITLE
Create CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,4 @@
-* @zaro0508 @xschildw
+* @Sage-Bionetworks/sagebio-it
 
 # For creation and termination of requests which are added to config/prod
 # add other individuals who have been trained on the process here.

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -5,4 +5,4 @@
 config/prod/* @zaro0508 @xschildw @kdaily @thomasyu888
 
 # For creation and removal of templates
-templates/* @zaro0508 @xschildw @kdaily @thomasyu888
+templates/ @Sage-Bionetworks/sagebio-it @Sage-Bionetworks/infra-oversight-committee

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+config/prod/* @zaro0508 @xschildw

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-config/prod/* @zaro0508 @xschildw
+config/prod/* @zaro0508 @xschildw @kdaily @thomasyu888

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,3 +3,6 @@
 # For creation and termination of requests which are added to config/prod
 # add other individuals who have been trained on the process here.
 config/prod/* @zaro0508 @xschildw @kdaily @thomasyu888
+
+# For creation and removal of templates
+templates/* @zaro0508 @xschildw @kdaily @thomasyu888

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,7 +2,7 @@
 
 # For creation and termination of requests which are added to config/prod
 # add other individuals who have been trained on the process here.
-config/prod/* @zaro0508 @xschildw @kdaily @thomasyu888
+config/* @Sage-Bionetworks/sagebio-it @Sage-Bionetworks/infra-oversight-committee
 
 # For creation and removal of templates
 templates/ @Sage-Bionetworks/sagebio-it @Sage-Bionetworks/infra-oversight-committee

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -5,4 +5,4 @@
 config/* @Sage-Bionetworks/sagebio-it @Sage-Bionetworks/infra-oversight-committee
 
 # For creation and removal of templates
-templates/ @Sage-Bionetworks/sagebio-it @Sage-Bionetworks/infra-oversight-committee
+templates/* @Sage-Bionetworks/sagebio-it @Sage-Bionetworks/infra-oversight-committee

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,5 @@
+* @zaro0508 @xschildw
+
+# For creation and termination of requests which are added to config/prod
+# add other individuals who have been trained on the process here.
 config/prod/* @zaro0508 @xschildw @kdaily @thomasyu888

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,7 +2,7 @@
 
 # For creation and termination of requests which are added to config/prod
 # add other individuals who have been trained on the process here.
-config/* @Sage-Bionetworks/sagebio-it @Sage-Bionetworks/infra-oversight-committee
+config/ @Sage-Bionetworks/sagebio-it @Sage-Bionetworks/infra-oversight-committee
 
 # For creation and removal of templates
-templates/* @Sage-Bionetworks/sagebio-it @Sage-Bionetworks/infra-oversight-committee
+templates/ @Sage-Bionetworks/sagebio-it @Sage-Bionetworks/infra-oversight-committee


### PR DESCRIPTION
Use this to enforce that PRs to create new stacks must be reviewed by specific people. Right now many people can approve and merge without it being checked. This can be enforced in the protected branch settings. Makes it so that only @zaro0508 and @xschildw can approve new stack creation. can adjust if necessary to add redundancy.