### PR TITLE
fix codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,8 +1,8 @@
-* @Sage-Bionetworks/sagebio-it
+/** @Sage-Bionetworks/sagebio-it
 
 # For creation and termination of requests which are added to config/prod
 # add other individuals who have been trained on the process here.
-config/ @Sage-Bionetworks/sagebio-it @Sage-Bionetworks/infra-oversight-committee
+config/ @Sage-Bionetworks/infra-oversight-committee
 
 # For creation and removal of templates
-templates/ @Sage-Bionetworks/sagebio-it @Sage-Bionetworks/infra-oversight-committee
+templates/ @Sage-Bionetworks/infra-oversight-committee


### PR DESCRIPTION
Github code owners was not auto assigning PRs to the sagebio-it
group.  Also sagebio-it users have been added to the
infra-oversight-committee