### PR TITLE
Allow provisioning of a generic bucket

### DIFF
--- a/templates/managed-s3.yaml
+++ b/templates/managed-s3.yaml
@@ -1,0 +1,211 @@
+Description: Provision a generic or a Synapse bucket
+AWSTemplateFormatVersion: 2010-09-09
+Parameters:
+  AllowWriteBucket:
+    Type: String
+    Description: true for read-write, false (default) for read-only bucket
+    AllowedValues:
+      - true
+      - false
+    Default: false
+  SynapseBucket:
+    Type: String
+    Description: true for a synapse bucket, false (default) for general bucket
+    AllowedValues:
+      - true
+      - false
+    Default: false
+  EncryptBucket:
+    Type: String
+    Description: true (default) to encrypt bucket, false for no encryption
+    AllowedValues:
+      - true
+      - false
+    Default: true
+  SameRegionResourceAccessToBucket:
+    Type: String
+    Description: >
+      THIS CURRENTLY ONLY WORKS IN THE us-east-1 REGION!!!!!
+      Data transfers within the same region between AWS resources are free.
+      true to restrict downloading files from this bucket to only AWS resources (e.g. EC2 , Lambda) within the same region as this bucket.
+      This will not allow even the owner of the bucket to download objects in this bucket when not using an AWS resource in the same region!
+    AllowedValues:
+      - true
+      - false
+    Default: false
+  BucketVersioning:
+    Type: String
+    Description: Enabled to enable bucket versionsing, default is Suspended
+    AllowedValues:
+      - Enabled
+      - Suspended
+    Default: Suspended
+  SynapseUserName:
+    Type: String
+    Description: Synapse user for read-write bucket
+  Department:
+    Description: The department for this resource (i.e. Computational Oncology)
+    Type: String
+  Project:
+    Description: The name of the project that this resource is used for (i.e. Resilience)
+    Type: String
+  OwnerEmail:
+    Type: String
+    Description: The bucket owner's email address
+  EnableDataLifeCycle:
+    Type: String
+    Description: Enabled to enable bucket lifecycle rule, default is Disabled
+    AllowedValues:
+      - Enabled
+      - Disabled
+    Default: Disabled
+  LifecycleDataTransition:
+    Type: Number
+    Description: Number of days until S3 objects are moved to LifecycleDataStorageClass
+    Default: 30
+  LifecycleDataStorageClass:
+    Type: String
+    Description: S3 bucket objects will transition into this storage class
+    AllowedValues:
+      - STANDARD_IA
+      - ONEZONE_IA
+      - GLACIER
+    Default: GLACIER
+  LifecycleDataExpiration:
+    Type: Number
+    Description: Number of days (from creation) when objects are deleted from S3 and the LifecycleDataStorageClass
+    Default: 365000
+Conditions:
+  AllowWrite: !Equals [!Ref AllowWriteBucket, true]
+  EnableSynapseBucket: !Equals [!Ref SynapseBucket, true]
+  EnableEncryption: !Equals [!Ref EncryptBucket, true]
+  DisableEncryption: !Not [!Condition EnableEncryption]
+  CreateIPAddressRestrictionLambda: !Equals [!Ref SameRegionResourceAccessToBucket, true]
+Resources:
+  S3Bucket:
+    Type: "AWS::S3::Bucket"
+    Condition: DisableEncryption
+    Properties:
+      VersioningConfiguration:
+        Status: !Ref BucketVersioning
+      CorsConfiguration:
+        CorsRules:
+          - Id: SynapseCORSRule
+            AllowedHeaders: ['*']
+            AllowedOrigins: ['*']
+            AllowedMethods: [GET, POST, PUT, HEAD]
+            MaxAge: 3000
+      LifecycleConfiguration:
+        Rules:
+        - Id: DataLifecycleRule
+          Status: !Ref EnableDataLifeCycle
+          ExpirationInDays: !Ref LifecycleDataExpiration
+          Transitions:
+            - TransitionInDays: !Ref LifecycleDataTransition
+              StorageClass: !Ref LifecycleDataStorageClass
+      Tags:
+        - Key: "Name"
+          Value: !Ref 'AWS::StackName'
+        - Key: "Department"
+          Value: !Ref Department
+        - Key: "Project"
+          Value: !Ref Project
+        - Key: "OwnerEmail"
+          Value: !Ref OwnerEmail
+  EncryptedS3Bucket:
+    Type: "AWS::S3::Bucket"
+    Condition: EnableEncryption
+    Properties:
+      VersioningConfiguration:
+        Status: !Ref BucketVersioning
+      BucketEncryption:
+        ServerSideEncryptionConfiguration:
+          - ServerSideEncryptionByDefault:
+              SSEAlgorithm: AES256
+      CorsConfiguration:
+        CorsRules:
+          - Id: SynapseCORSRule
+            AllowedHeaders: ['*']
+            AllowedOrigins: ['*']
+            AllowedMethods: [GET, POST, PUT, HEAD]
+            MaxAge: 3000
+      LifecycleConfiguration:
+        Rules:
+        - Id: DataLifecycleRule
+          Status: !Ref EnableDataLifeCycle
+          ExpirationInDays: !Ref LifecycleDataExpiration
+          Transitions:
+            - TransitionInDays: !Ref LifecycleDataTransition
+              StorageClass: !Ref LifecycleDataStorageClass
+      Tags:
+        - Key: "Name"
+          Value: !Ref 'AWS::StackName'
+        - Key: "Department"
+          Value: !Ref Department
+        - Key: "Project"
+          Value: !Ref Project
+        - Key: "OwnerEmail"
+          Value: !Ref OwnerEmail
+
+  ExternalBucketPolicy:
+    Type: "AWS::S3::BucketPolicy"
+    Condition: EnableSynapseBucket
+    Properties:
+      Bucket: !If [EnableEncryption, !Ref EncryptedS3Bucket, !Ref S3Bucket]
+      PolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          -
+            Sid: "ReadAccess"
+            Effect: "Allow"
+            Principal:
+              AWS: "325565585839"
+            Action: "s3:ListBucket*"
+            Resource: !If [EnableEncryption, !GetAtt EncryptedS3Bucket.Arn, !GetAtt S3Bucket.Arn]
+          -
+            Sid: "WriteAccess"
+            Effect: "Allow"
+            Principal:
+              AWS: "325565585839"
+            Action:
+              - !If [AllowWrite, "s3:*Object*", "s3:GetObject*"]
+              - "s3:*MultipartUpload*"
+            Resource: !If [EnableEncryption, !Sub "${EncryptedS3Bucket.Arn}/*", !Sub "${S3Bucket.Arn}/*"]
+
+  IPAddressRestictionLambda:
+    Type: 'AWS::CloudFormation::Stack'
+    Condition: CreateIPAddressRestrictionLambda
+    Properties:
+      # template uploaded from Sage-Bionetworks/aws-infra repo
+      TemplateURL: 'https://s3.amazonaws.com/bootstrap-awss3cloudformationbucket-19qromfd235z9/aws-infra/v0.0.4/AddSameRegionBucketDownloadRestriction.yaml'
+      Parameters:
+        BucketName: !If [EnableEncryption, !Ref EncryptedS3Bucket, !Ref S3Bucket]
+      Tags:
+        - Key: "Name"
+          Value: !Ref 'AWS::StackName'
+        - Key: "Department"
+          Value: !Ref Department
+        - Key: "Project"
+          Value: !Ref Project
+        - Key: "OwnerEmail"
+          Value: !Ref OwnerEmail
+
+Outputs:
+  S3Bucket:
+    Condition: DisableEncryption
+    Value: !Ref S3Bucket
+    Export:
+      Name: !Sub '${AWS::Region}-${AWS::StackName}-S3Bucket'
+  EncryptedS3Bucket:
+    Condition: EnableEncryption
+    Value: !Ref EncryptedS3Bucket
+    Export:
+      Name: !Sub '${AWS::Region}-${AWS::StackName}-S3Bucket'
+  SynapseUserName:
+    Value: !Ref SynapseUserName
+    Export:
+      Name: !Sub '${AWS::Region}-${AWS::StackName}-SynapseUserName'
+  OwnerEmail:
+    Value: !Ref OwnerEmail
+    Export:
+      Name: !Sub '${AWS::Region}-${AWS::StackName}-OwnerEmail'


### PR DESCRIPTION
Make this script default to provision a generic bucket.  A generic
bucket is a bucket that does not have any policies applied to it.
An optional parameter is provided to make it a Synapse Custom bucket.