### PR TITLE
create a bucket for MSSM to transfer files

### DIFF
--- a/config/prod/mssm-transfer-bucket.yaml
+++ b/config/prod/mssm-transfer-bucket.yaml
@@ -1,0 +1,21 @@
+# Provision a Synapse External Bucket (http://docs.synapse.org/articles/custom_storage_location.html)
+template_path: SynapseExternalBucket-v2.yaml
+stack_name: mssm-transfer-bucket
+parameters:
+  # The Sage deparment for this resource
+  Department: "SysBio"
+  # The Sage project this resource will be used for
+  Project: "AMPAD-Workflows"
+  # The resource owner
+  OwnerEmail: "anna.greenwood@sagebase.org"
+  # true for read-write bucket, false (default) for read-only bucket
+  AllowWriteBucket: 'true'
+  # Synapse username
+  SynapseUserName: 'ew3388@synapse.org'
+  # (Optional) Allow accounts, groups, and users to access bucket.
+  GrantAccess:
+    - 'arn:aws:iam::325565585839:root'   # Required ARN for a synapse bucket
+    - 'arn:aws:iam::563295687221:user/mssm@sagebase.org'
+hooks:
+  after_create:
+    - !synapse_bucket_notify {{stack_group_config.aws_account_name}} {{stack_group_config.aws_account_email}}


### PR DESCRIPTION
This is related to commit 335107f

Our collaborators at MSSM do not want to create an AWS account for
us to setup cross account access for them to access one of our buckets
so they can transfer files to Sage.

After further discussion with MSSM we've decided to provide MSSM
with an Sage IAM account user access key with access to the bucket.