### PR TITLE
Increase travis wait time

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,4 +21,4 @@ jobs:
     - stage: validate
       script: cfn-lint ./templates/**/*
     - stage: deploy
-      script: sceptre launch prod --yes
+      script: travis_wait 30 sceptre launch prod --yes


### PR DESCRIPTION
Some AWS resources, like cloudfront, can take a long time to deploy
without logging status to the console.  We increase travis_wait[1]
so the build won't timeout and fail.

[1] https://docs.travis-ci.com/user/common-build-problems/#build-times-out-because-no-output-was-received