### PR TITLE
[IT-506] flag colon spacing in yaml as errors

### DIFF
--- a/.yamllint
+++ b/.yamllint
@@ -9,8 +9,6 @@ rules:
   brackets:
     level: warning
     max-spaces-inside: 1
-  colons:
-    level: warning
   commas:
     level: warning
   comments: disable


### PR DESCRIPTION
To help validate that there are no duplicatee stack_name in new PRs
we need to be ore strick with the yaml to provision resources.
This will flag colons spacing issues[1] as errors instead of warnings.

[1] https://yamllint.readthedocs.io/en/stable/rules.html#module-yamllint.rules.colons