### PR TITLE
lint_stack.sh no longer requires a parameter

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ jobs:
     - stage: validate
       script:
         - yamllint ./config ./templates
-        - ./lint_stack.sh -p ./config/prod
+        - ./lint_stack.sh
         - cfn-lint ./templates/**/*
     - stage: deploy
       script: travis_wait 30 sceptre launch prod --yes


### PR DESCRIPTION
a change to lint_stack.sh script no longer requires passing
in a parameter:
https://github.com/Sage-Bionetworks/infra-utils/commit/166075f275cac9b1c554cfc2b6a14ed38a6a4898