### PR TITLE
[IT-506] lint newly provisioned stack name for errors

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,10 @@ jobs:
     - stage: validate
       script:
         - yamllint ./config ./templates
+        - ./lint_stack.sh -l ./config/prod
         - cfn-lint ./templates/**/*
     - stage: deploy
-      script: travis_wait 30 sceptre launch prod --yes
+      script:
+        - ./lint_stack.sh -r
+        - travis_wait 30 sceptre launch prod --yes
+


### PR DESCRIPTION
Use lint_stack[1] to validate the following items for newly

provisioned stack name:
1. stack name contains valid characters.
2. stack name is not a duplicate of existing stack names.

[1] https://github.com/Sage-Bionetworks/infra-utils/blob/master/ci/lint_stack.sh
fde8f8f
