### PR TITLE
[IT-488] Use shared EC2 provisioner template

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -7,3 +7,7 @@ admincentral_cf_bucket: "bootstrap-awss3cloudformationbucket-19qromfd235z9"
 # Sender for notification hooks
 aws_account_name: Sandbox
 aws_account_email: aws.sandbox@sagebase.org
+# Provisioner defaults
+default_ami: "ami-0080e4c5bc078760e"
+default_key_pair: "sandbox"
+default_vpc: "sandcastlevpc"

--- a/templates/managed-ec2-v6.yaml
+++ b/templates/managed-ec2-v6.yaml
@@ -1,3 +1,7 @@
+#######################################################
+# THIS TEMPLATE IS DEPRECATED, PLEASE USE:
+# https://github.com/Sage-Bionetworks/aws-infra/tree/master/templates/managed-ec2-v7.yaml
+#######################################################
 AWSTemplateFormatVersion: 2010-09-09
 Description: >-
   Provision EC2 instance, connect to Jumpcloud, and associate with a jumpcloud systems group.


### PR DESCRIPTION
All provisioning using the new template
Sage-Bionetworks/aws-infra/templates/managed-ec2-v7.yaml
will need to set these params

```
  template_path: remote/managed-ec2-v7.yaml

  # Defaults account settings
  AMIId: {{stack_group_config.default_ami}}
  KeyName: {{stack_group_config.default_key_pair}}
  VpcName: {{stack_group_config.default_vpc}}

  # Integration with CI system (do not change)
  hooks:
    before_create:
      - !cmd "curl https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/aws-infra/master/managed-ec2-v7.yaml --create-dirs -o templates/remote/managed-ec2-v7.yaml"
    before_update:
      - !cmd "curl https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/aws-infra/master/managed-ec2-v7.yaml --create-dirs -o templates/remote/managed-ec2-v7.yaml"
    after_create:
      - !ec2_notify "{{stack_group_config.aws_account_name}} {{stack_group_config.aws_account_email}}"
```

This PR depends on https://github.com/Sage-Bionetworks/aws-infra/pull/106