### PR TITLE
remove invalid principal from s3 policy

### DIFF
--- a/config/prod/dgutman-htan-s3.yaml
+++ b/config/prod/dgutman-htan-s3.yaml
@@ -20,7 +20,6 @@ parameters:
   # (Optional) Allow accounts, groups, and users to access bucket. (default is no access).
   GrantAccess:
     - 'arn:aws:iam::325565585839:root'   # Required ARN for a synapse bucket
-    - 'arn:aws:iam::289701539771:dagutman'
     - 'arn:aws:iam::563295687221:user/xengie.doan@sagebase.org'
   # (Optional) true (default) to encrypt bucket, false for no encryption
   # EncryptBucket: 'false'


### PR DESCRIPTION
cloudformation reports that there is an invalid principal in s3 policy.
i suspect it's the dgutman ARN.

CF error message:

ExternalBucketPolicy AWS::S3::BucketPolicy CREATE_FAILED Invalid principal in policy
(Service: Amazon S3; Status Code: 400; Error Code: MalformedPolicy;
Request ID: E6C52D0405DF833C; S3 Extended Request
ID: 4NTE0nmra7HWcOO6CFUTw7KTw1rd5aIkhO00XPwxoLB3Uc6zKxPUU8pG//WeN+ZXg2q1XouJsrQ=)