### PR TITLE
Fix ubuntu deployment

### DIFF
--- a/config/prod/tom-test-ubuntu.yaml
+++ b/config/prod/tom-test-ubuntu.yaml
@@ -1,5 +1,5 @@
 # Provision an EC2 instance
-template_path: remote/managed-ec2.yaml
+template_path: remote/managed-ec2-ubuntu-v1.yaml
 stack_name: tom-test-ubuntu
 parameters:
   # The Sage deparment (Platform, CompOnc, SysBio, Governance, etc..)
@@ -39,8 +39,8 @@ parameters:
 # For CI system (do not change)
 hooks:
   before_create:
-    - !cmd "curl https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/aws-infra/master/managed-ec2-ubuntu-v1.yaml --create-dirs -o templates/remote/managed-ec2.yaml"
+    - !cmd "curl https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/aws-infra/master/managed-ec2-ubuntu-v1.yaml --create-dirs -o templates/remote/managed-ec2-ubuntu-v1.yaml"
   before_update:
-    - !cmd "curl https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/aws-infra/master/managed-ec2-ubuntu-v1.yaml --create-dirs -o templates/remote/managed-ec2.yaml"
+    - !cmd "curl https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/aws-infra/master/managed-ec2-ubuntu-v1.yaml --create-dirs -o templates/remote/managed-ec2-ubuntu-v1.yaml"
   after_create:
     - !ec2_notify "{{stack_group_config.aws_account_name}} {{stack_group_config.aws_account_email}}"


### PR DESCRIPTION
This is failing on travis only, it works when deployed locally.  The
problem seems to be that it's using the aws linux template[1] instead
of the ubuntu template.  My guess is that travis is over aggressively
cacheing files therefore not replacing the aws linux template.

We attempt to fix by downloading to a different file.