### PR TITLE
Requesting Ubuntu RStudio AMI

### DIFF
--- a/config/prod/ubuntu-rstudio-ami.yaml
+++ b/config/prod/ubuntu-rstudio-ami.yaml
@@ -1,46 +1,49 @@
 # Provision an EC2 instance
-template_path: remote/managed-ec2-ubuntu-v1.yaml
+template_path: remote/managed-ec2-ubuntu-v2.j2
 stack_name: ubuntu-rstudio-instance
 parameters:
-# The Sage deparment (Platform, CompOnc, SysBio, Governance, etc..)
-Department: "CompOnc"
-# The Sage project (Infrastructure, amp-ad, ntap, dream, etc..)
-Project: "NF-Hackathon-harmonized-files"
-# The resource owner
-OwnerEmail: "jineta.banerjee@sagebase.org"
+  # The Sage deparment (Platform, CompOnc, SysBio, Governance, etc..)
+  Department: "CompOnc"
+  # The Sage project (Infrastructure, amp-ad, ntap, dream, etc..)
+  Project: "NF-Hackathon-harmonized-files"
+  # The resource owner
+  OwnerEmail: "jineta.banerjee@sagebase.org"
 
-# Default account settings, leave alone unless you plan to override
-# VpcName: "{{stack_group_config.default_vpc}}"
-# KeyName: "{{stack_group_config.default_key_pair}}"
-# AMIId: "{{stack_group_config.default_ubuntu_ami}}"
+  # Default account settings, leave alone unless you plan to override
+  # VpcName: "{{stack_group_config.default_vpc}}"
+  # KeyName: "{{stack_group_config.default_key_pair}}"
+  # AMIId: "{{stack_group_config.default_ubuntu_ami}}"
 
-# Settings have default values but can be overriden. Set the below
-# parameters *only* if you want to override the defaults.
+  # Settings have default values but can be overriden. Set the below
+  # parameters *only* if you want to override the defaults.
 
-# (Optional) EC2 instance type, default is "t3.nano" (other available types https://aws.amazon.com/ec2/instance-types/)
-InstanceType: "t3.xlarge"
-# (Optional) EC2 boot volume size in GB, default is 8GB, Max is 1000GB
-VolumeSize: "500"
-# (Optional) Base instance on AMI (default: ami-0a313d6098716f372)
-AMIId: "ami-061a59e27c8da0b93"
-# (Optional) Run EC2 in a subnet (default: PrivateSubnet) (valid values: PrivateSubnet or PublicSubnet)
-# VpcSubnet: "PublicSubnet"
-# (Optional) Expose a port to incoming traffic (default is no open ports) (valid range: 1-65535)
-# OpenPort: "80"
-# (Optional) Set true to enable daily backups (default: false)
-# BackupEc2: "true"
-# (Optional) Number of daily backups to keep (default: 7) (valid range: 1-180)
-# SnapshotCount: "14"
+  # (Optional) EC2 instance type, default is "t3.nano" (other available types https://aws.amazon.com/ec2/instance-types/)
+  InstanceType: "t3.xlarge"
+  # (Optional) EC2 boot volume size in GB, default is 8GB, Max is 1000GB
+  VolumeSize: "500"
+  # (Optional) Base instance on AMI (default: ami-0a313d6098716f372)
+  AMIId: "ami-061a59e27c8da0b93"
+  # (Optional) Run EC2 in a subnet (default: PrivateSubnet) (valid values: PrivateSubnet or PublicSubnet)
+  # VpcSubnet: "PublicSubnet"
+  # (Optional) Set true to enable daily backups (default: false)
+  # BackupEc2: "true"
+  # (Optional) Number of daily backups to keep (default: 7) (valid range: 1-180)
+  # SnapshotCount: "14"
 
-# Integration with our jumpcloud directory service (do not change)
-JcConnectKey: !ssm /infra/JcConnectKey
-JcServiceApiKey: !ssm /infra/JcServiceApiKey
-JcSystemsGroupId: !ssm /infra/JcSystemsGroupId
+  # Integration with our jumpcloud directory service (do not change)
+  JcConnectKey: !ssm /infra/JcConnectKey
+  JcServiceApiKey: !ssm /infra/JcServiceApiKey
+  JcSystemsGroupId: !ssm /infra/JcSystemsGroupId
+
+#sceptre_user_data:
+  # (Optional) Expose ports to incoming traffic (default is no open ports) (valid range: 1-65535)
+  # OpenPorts: ["80","443"]
+
 # For CI system (do not change)
 hooks:
   before_create:
-    - !cmd "curl https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/aws-infra/master/managed-ec2-ubuntu-v1.yaml --create-dirs -o templates/remote/managed-ec2-ubuntu-v1.yaml"
+    - !cmd "curl https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/aws-infra/master/managed-ec2-ubuntu-v2.j2 --create-dirs -o templates/remote/managed-ec2-ubuntu-v2.j2"
   before_update:
-    - !cmd "curl https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/aws-infra/master/managed-ec2-ubuntu-v1.yaml --create-dirs -o templates/remote/managed-ec2-ubuntu-v1.yaml"
+    - !cmd "curl https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/aws-infra/master/managed-ec2-ubuntu-v2.j2 --create-dirs -o templates/remote/managed-ec2-ubuntu-v2.j2"
   after_create:
     - !ec2_notify "{{stack_group_config.aws_account_name}} {{stack_group_config.aws_account_email}}"

--- a/config/prod/ubuntu-rstudio-ami.yaml
+++ b/config/prod/ubuntu-rstudio-ami.yaml
@@ -1,0 +1,46 @@
+# Provision an EC2 instance
+template_path: remote/managed-ec2-ubuntu-v1.yaml
+stack_name: ubuntu-rstudio-instance
+parameters:
+# The Sage deparment (Platform, CompOnc, SysBio, Governance, etc..)
+Department: "CompOnc"
+# The Sage project (Infrastructure, amp-ad, ntap, dream, etc..)
+Project: "NF-Hackathon-harmonized-files"
+# The resource owner
+OwnerEmail: "jineta.banerjee@sagebase.org"
+	
+# Default account settings, leave alone unless you plan to override
+# VpcName: "{{stack_group_config.default_vpc}}"
+# KeyName: "{{stack_group_config.default_key_pair}}"
+# AMIId: "{{stack_group_config.default_ubuntu_ami}}"
+
+# Settings have default values but can be overriden. Set the below
+# parameters *only* if you want to override the defaults.
+
+# (Optional) EC2 instance type, default is "t3.nano" (other available types https://aws.amazon.com/ec2/instance-types/)
+InstanceType: "t3.xlarge"
+# (Optional) EC2 boot volume size in GB, default is 8GB, Max is 1000GB
+VolumeSize: "500"
+# (Optional) Base instance on AMI (default: ami-0a313d6098716f372)
+AMIId: "ami-061a59e27c8da0b93"
+# (Optional) Run EC2 in a subnet (default: PrivateSubnet) (valid values: PrivateSubnet or PublicSubnet)
+# VpcSubnet: "PublicSubnet"
+# (Optional) Expose a port to incoming traffic (default is no open ports) (valid range: 1-65535)
+# OpenPort: "80"
+# (Optional) Set true to enable daily backups (default: false)
+# BackupEc2: "true"
+# (Optional) Number of daily backups to keep (default: 7) (valid range: 1-180)
+# SnapshotCount: "14"
+	
+# Integration with our jumpcloud directory service (do not change)
+JcConnectKey: !ssm /infra/JcConnectKey
+JcServiceApiKey: !ssm /infra/JcServiceApiKey
+JcSystemsGroupId: !ssm /infra/JcSystemsGroupId
+# For CI system (do not change)
+hooks:
+  before_create:
+    - !cmd "curl https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/aws-infra/master/managed-ec2-ubuntu-v1.yaml --create-dirs -o templates/remote/managed-ec2-ubuntu-v1.yaml"
+  before_update:
+    - !cmd "curl https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/aws-infra/master/managed-ec2-ubuntu-v1.yaml --create-dirs -o templates/remote/managed-ec2-ubuntu-v1.yaml"
+  after_create:
+    - !ec2_notify "{{stack_group_config.aws_account_name}} {{stack_group_config.aws_account_email}}"

--- a/config/prod/ubuntu-rstudio-ami.yaml
+++ b/config/prod/ubuntu-rstudio-ami.yaml
@@ -12,7 +12,7 @@ parameters:
   # Default account settings, leave alone unless you plan to override
   VpcName: "{{stack_group_config.default_vpc}}"
   KeyName: "{{stack_group_config.default_key_pair}}"
-  AMIId: "{{stack_group_config.default_ubuntu_ami}}"
+  # AMIId: "{{stack_group_config.default_ubuntu_ami}}"
 
   # Settings have default values but can be overriden. Set the below
   # parameters *only* if you want to override the defaults.

--- a/config/prod/ubuntu-rstudio-ami.yaml
+++ b/config/prod/ubuntu-rstudio-ami.yaml
@@ -8,7 +8,7 @@ Department: "CompOnc"
 Project: "NF-Hackathon-harmonized-files"
 # The resource owner
 OwnerEmail: "jineta.banerjee@sagebase.org"
-	
+
 # Default account settings, leave alone unless you plan to override
 # VpcName: "{{stack_group_config.default_vpc}}"
 # KeyName: "{{stack_group_config.default_key_pair}}"
@@ -31,7 +31,7 @@ AMIId: "ami-061a59e27c8da0b93"
 # BackupEc2: "true"
 # (Optional) Number of daily backups to keep (default: 7) (valid range: 1-180)
 # SnapshotCount: "14"
-	
+
 # Integration with our jumpcloud directory service (do not change)
 JcConnectKey: !ssm /infra/JcConnectKey
 JcServiceApiKey: !ssm /infra/JcServiceApiKey

--- a/config/prod/ubuntu-rstudio-ami.yaml
+++ b/config/prod/ubuntu-rstudio-ami.yaml
@@ -10,9 +10,9 @@ parameters:
   OwnerEmail: "jineta.banerjee@sagebase.org"
 
   # Default account settings, leave alone unless you plan to override
-  # VpcName: "{{stack_group_config.default_vpc}}"
-  # KeyName: "{{stack_group_config.default_key_pair}}"
-  # AMIId: "{{stack_group_config.default_ubuntu_ami}}"
+  VpcName: "{{stack_group_config.default_vpc}}"
+  KeyName: "{{stack_group_config.default_key_pair}}"
+  AMIId: "{{stack_group_config.default_ubuntu_ami}}"
 
   # Settings have default values but can be overriden. Set the below
   # parameters *only* if you want to override the defaults.


### PR DESCRIPTION
Requesting an ubuntu instance to run a publicly available Rstudio AMI (http://www.louisaslett.com/RStudio_AMI/) in US-East1 zone with increased instance size.

-Removed tabs/spaces causing earlier errors in PR
-OK with pre-inspection of the public AMI by sage IT team