### PR TITLE
fix tom-est-ubuntu16 instance

### DIFF
--- a/config/prod/tom-test-ubuntu16.yaml
+++ b/config/prod/tom-test-ubuntu16.yaml
@@ -20,7 +20,7 @@ parameters:
   # (Optional) EC2 instance type, default is "t3.nano" (other available types https://aws.amazon.com/ec2/pricing/on-demand/)
   #  InstanceType: "t3.large"
   # (Optional) EC2 boot volume size in GB, default is 8GB, Max is 1000GB
-  # VolumeSize: "50"
+  VolumeSize: "110"
   # (Optional) Run EC2 in a subnet (default: PrivateSubnet) (valid values: PrivateSubnet or PublicSubnet)
   # VpcSubnet: "PublicSubnet"
   # (Optional) Set true to enable daily backups (default: false)


### PR DESCRIPTION
provisioner failed with message:
[2019-07-03 01:51:11] - prod/tom-test-ubuntu16 Ec2Instance AWS::EC2::Instance
CREATE_FAILED Volume of size 8GB is smaller than  snapshot
'snap-0a6548e5ad1936d4b', expect size >= 100GB (Service: AmazonEC2;
Status Code: 400; Error Code: InvalidBlockDeviceMapping;
Request ID: 401e3b5d-ce96-4f3c-8ca6-8c871a3b824a)

Attempt to fix instance