### PR TITLE
changing instance type to general purpose instance

### DIFF
--- a/config/prod/ubuntu-rstudio-ami.yaml
+++ b/config/prod/ubuntu-rstudio-ami.yaml
@@ -18,7 +18,7 @@ parameters:
   # parameters *only* if you want to override the defaults.
 
   # (Optional) EC2 instance type, default is "t3.nano" (other available types https://aws.amazon.com/ec2/instance-types/)
-  InstanceType: "r5.24xlarge"
+  InstanceType: "m5.4xlarge"
   # (Optional) EC2 boot volume size in GB, default is 8GB, Max is 1000GB
   VolumeSize: "500"
   # (Optional) Base instance on AMI (default: ami-0a313d6098716f372)


### PR DESCRIPTION
The memory intensive analysis is finished, so now changing the instance type back to general purpose to carry on analyses that are not super memory intensive.