### PR TITLE
Changing instance type back to compute optimized

### DIFF
--- a/config/prod/nf-vcf-proc.yaml
+++ b/config/prod/nf-vcf-proc.yaml
@@ -18,7 +18,7 @@ parameters:
   # parameters *only* if you want to override the defaults.
 
   # (Optional) EC2 instance type, default is "t2.nano" (other available types https://aws.amazon.com/ec2/pricing/on-demand/)
-  InstanceType: "r5.2xlarge"
+  InstanceType: "c5d.18xlarge"
   # (Optional) EC2 boot volume size in GB, default is 8GB, Max is 1000GB
   VolumeSize: "500"
   # (Optional) Base instance on AMI (default: ami-0de53d8956e8dcf80)


### PR DESCRIPTION
The instance type for this stack was mistakenly changed by Sara. Changing it back to compute optimized for further VCF processing.