### PR TITLE
Add bucket replication lambda CF template

### DIFF
--- a/config/prod/ecmonsen-emorypipeline.yaml
+++ b/config/prod/ecmonsen-emorypipeline.yaml
@@ -1,0 +1,9 @@
+template_path: ecmonsen-emorypipeline.yaml
+stack_name: ecmonsen-emorypipeline
+parameters:
+  # The Sage deparment (Platform, CompOnc, SysBio, Governance, etc..)
+  Department: "SysBio"
+  # The Sage project (Infrastructure, amp-ad, ntap, dream, etc..)
+  Project: "amp-ad"
+  # The resource owner
+  OwnerEmail: "eva.monsen@sagebase.org"

--- a/templates/bucket-replication-lambda.yaml
+++ b/templates/bucket-replication-lambda.yaml
@@ -69,6 +69,7 @@ Resources:
     Type: AWS::IAM::Policy
     Properties:
       #Description: Allows access to the S3 data bucket and CloudWatch logs.
+      PolicyName: !Sub ${AWS::StackName}-LambdaExecutionPolicy
       Roles: [!Ref 'LambdaExecutionRole']
       PolicyDocument:
         Statement:

--- a/templates/bucket-replication-lambda.yaml
+++ b/templates/bucket-replication-lambda.yaml
@@ -1,15 +1,35 @@
-# This template creates an S3 bucket and a Lambda function
+# This template creates an S3 bucket and a Lambda function to automate file upload to Synapse.
 #
 # The S3 bucket is granted permissions to be a Synapse storage location, *and* an S3 replication destination
 # from a collaborator's AWS account.
 #
+# Lambda Code is here: https://github.com/ecmonsen/Synapse-replication-uploader
+#
 # The Lambda function is triggered by PUT requests to the bucket. It reads the files, computes and writes md5 sums
 # back to the bucket, and adds file handles to Synapse.
 #
-# This stack will need to be created with SynapseStorageLocationId = "" (blank). After the bucket is created,
-# the Synapse storage location must be created externally. Then update the stack with the new value for
-# SynapseStorageLocationId.
+# BEFORE STACK CREATION:
 #
+# 1. Use AWS SAM to package the Lambda code and upload it to an S3 bucket. The S3 bucket must be readable by the
+# identity creating the CloudFormation stack. Provide the S3 bucket and key as parameters FunctionCodeBucket and
+# FunctionCodeKey to CloudFormation.
+#
+# ADDITIONAL ACTIONS REQUIRED AFTER STACK CREATION:
+#
+# 1. After the stack creates the S3 bucket, you will need to use Synapse API or CLI to create an external
+# Synapse storage location must pointing to the bucket. Then update the stack with the new value for
+# SynapseStorageLocationId. Use code or web as specified here:
+# https://docs.synapse.org/articles/custom_storage_location.html#set-s3-bucket-as-upload-location
+#
+# Here's a handy command line for getting the bucket name:
+# `aws cloudformation describe-stacks --stack-name "${STACKNAME}" --query "Stacks[0].Outputs[?OutputKey=='DataBucketName'].OutputValue" --output text`
+#
+# 2. Update the Secrets Manager secret value with the contents of a Synapse config file. The config file
+# should have the credentials of the Synapse on whose behalf the Lambda will do uploads. This can be done using
+# the AWS console or the CLI with these commands (you will need to be admin or assume an admin role to encrypt secrets):
+#
+# `SECRET_NAME=$(aws cloudformation describe-stacks --stack-name "${STACKNAME}" --query "Stacks[0].Outputs[?OutputKey=='CredentialsSecretName'].OutputValue" --output text)`
+# `aws secretsmanager put-secret-value --secret-id "$SECRET_NAME" --secret-binary fileb://path/to/.synapseConfig`
 
 AWSTemplateFormatVersion: "2010-09-09"
 
@@ -20,18 +40,22 @@ Parameters:
   FunctionCodeKey:
     Type: String
     Description: S3 key of lambda deployment package file
-  SynapseUsername:
+  SynapseConfig:
     Type: String
-    Description: Synapse username used to create files in Synapse.
-  SynapseApikey:
-    Type: String
-    Description: Synapse API key (associated with SynapseUsername) used to authenticate to Synapse.
+    Description: >
+      Contents of a .synapseConfig file containing Synapse username and API key.
+      Minimum contents required are these three lines:
+      [authentication]
+      username = <user name>
+      apikey = <api key>
+    Default: "To Do: Replace with a valid .synapseConfig with credentials"
   SynapseStorageLocationId:
     Type: Number
     Description: >
       Integer location ID for the bucket containing the files to be added to Synapse. Note a blank value should
       be provided the when the stack is created.
       See https://docs.synapse.org/articles/custom_storage_location.html
+    Default: -1
   SynapseNotifyUsers:
     Type: String
     Description: >
@@ -52,7 +76,72 @@ Parameters:
     Description:
       Maximum block size allocated to computing MD5 sums, in bytes.
 
+Mappings:
+  AdminRoleArns:
+    "563295687221":
+      Arn: "arn:aws:iam::563295687221:role/accounts-AWSIAMAdminRole-1B5HUQPC19H69"
+    "055273631518":
+      Arn: "arn:aws:iam::055273631518:role/accounts-AWSIAMAdminRole-JL0BF315YDU0"
+    "398582528253":
+      # Note: Groups not allowed. Create a role that root can assume
+      Arn: "arn:aws:iam::398582528253:role/AdminRole"
+
 Resources:
+  KmsKey:
+    Type: "AWS::KMS::Key"
+    Properties:
+      Description: !Sub "${AWS::StackName}Key"
+      KeyPolicy:
+        Version: "2012-10-17"
+        Statement:
+          - Sid: "Allow administration of the key"
+            Effect: "Allow"
+            Principal:
+              AWS:
+                - !Sub 'arn:aws:iam::${AWS::AccountId}:root'
+            Action:
+              - "kms:Create*"
+              - "kms:Describe*"
+              - "kms:Enable*"
+              - "kms:List*"
+              - "kms:Put*"
+              - "kms:Update*"
+              - "kms:Revoke*"
+              - "kms:Disable*"
+              - "kms:Get*"
+              - "kms:Delete*"
+              - "kms:ScheduleKeyDeletion"
+              - "kms:CancelKeyDeletion"
+            Resource: "*"
+          # TEMP: for testing the key
+          - Sid: "Allow use of the key"
+            Effect: "Allow"
+            Principal:
+              AWS:
+                - !FindInMap [AdminRoleArns, !Ref "AWS::AccountId", Arn]
+                - !GetAtt LambdaExecutionRole.Arn
+            Action:
+              - "kms:Encrypt"
+              - "kms:Decrypt"
+              - "kms:DescribeKey"
+              - "kms:Generate*"
+              - "kms:*"
+            Resource: "*"
+            # TODO: Allow lambda to decrypt only; allow other user(s) to encrypt
+            # TODO tags on everything
+#      Tags:
+#        - Key: "Department"
+#          Value: !Ref Department
+#        - Key: "Project"
+#          Value: !Ref Project
+#        - Key: "OwnerEmail"
+#          Value: !Ref OwnerEmail
+
+  KmsKeyAlias:
+    Type: AWS::KMS::Alias
+    Properties:
+      AliasName: !Sub "alias/${AWS::StackName}/Key"
+      TargetKeyId: !Ref KmsKey
 
   LambdaExecutionRole:
     Type: AWS::IAM::Role
@@ -91,6 +180,21 @@ Resources:
               - s3:GetObject
             Resource:
               - !Sub "arn:aws:s3:::${AWS::StackName}-data/*"
+          - Action: ['kms:*']
+            Effect: Allow
+            Resource: !GetAtt KmsKey.Arn
+          - Action: ['secretsmanager:GetSecretValue']
+            Effect: Allow
+            Resource: !Ref SynapseCredentialsSecret
+
+  SynapseCredentialsSecret:
+    Type: 'AWS::SecretsManager::Secret'
+    Properties:
+      Description: API key used to access Synapse
+      SecretString: !Ref SynapseConfig
+      KmsKeyId: !Ref KmsKey
+      # Need explicit name so that it can be referenced by the Lambda function
+      Name: !Sub "${AWS::Region}-${AWS::StackName}-SynapseCredentialsSecret"
 
   BucketToSynapseFunction:
     Type: AWS::Lambda::Function
@@ -101,11 +205,11 @@ Resources:
       Description: Adds files from an S3 bucket to Synapse.
       Environment:
         Variables:
-          SYNAPSE_USERNAME: !Ref SynapseUsername
-          SYNAPSE_APIKEY: !Ref SynapseApikey
+          CREDENTIALS_SECRET_NAME: !Sub "${AWS::Region}-${AWS::StackName}-SynapseCredentialsSecret"
           SYNAPSE_SOURCE_BUCKET_STORAGE_LOCATION_ID: !Ref SynapseStorageLocationId
           SYNAPSE_NOTIFY_USERS: !Ref SynapseNotifyUsers
           MD5_BLOCK_SIZE: !Ref Md5BlockSize
+          KMS_KEY_ARN: !Ref KmsKey
       Handler: lambda_function.lambda_handler
       Runtime: python3.7
       Timeout: 300
@@ -113,7 +217,8 @@ Resources:
 
   DataBucket:
     Type: AWS::S3::Bucket
-    DeletionPolicy: Delete
+    # Data needs to live on even if the other infrastructure is removed
+    DeletionPolicy: Retain
     DependsOn:
       - LambdaExecutionRolePolicy
     Properties:
@@ -168,6 +273,7 @@ Resources:
               AWS: !Sub arn:aws:iam::${ReplicationSourceAccountId}:root
             Action:
               - s3:GetBucketVersioning
+              - s3:PutBucketVersioning
               - s3:ReplicateObject
               - s3:ReplicateDelete
               - s3:ObjectOwnerOverrideToBucketOwner
@@ -187,3 +293,33 @@ Outputs:
       Name: !Sub "${AWS::Region}-${AWS::StackName}-DataBucketArn"
     Description: ARN of the data bucket that was created
     Value: !GetAtt DataBucket.Arn
+  DataBucketName:
+    Export:
+      Name: !Sub "${AWS::Region}-${AWS::StackName}-DataBucketName"
+    Description: ARN of the data bucket that was created
+    Value: !Ref DataBucket
+  KmsKeyArn:
+    Export:
+      Name: !Sub "${AWS::Region}-${AWS::StackName}-KmsKeyArn"
+    Description: ARN of the KMS key
+    Value: !GetAtt KmsKey.Arn
+  KmsKeyAliasName:
+    Export:
+      Name: !Sub "${AWS::Region}-${AWS::StackName}-KmsKeyAliasArn"
+    Description: ARN of the KMS key alias
+    Value: !Ref KmsKeyAlias
+  KmsKeyUsageRole:
+    Export:
+      Name: !Sub "${AWS::Region}-${AWS::StackName}-KmsKeyUsageRole"
+    Description: Role that was granted usage access to the KMS key
+    Value: !FindInMap [AdminRoleArns, !Ref "AWS::AccountId", Arn]
+  LambdaExecutionRoleArn:
+    Export:
+      Name: !Sub "${AWS::Region}-${AWS::StackName}-LambdaExecutionRoleArn"
+    Description: ARN of the lambda execution role
+    Value: !GetAtt LambdaExecutionRole.Arn
+  CredentialsSecretName:
+    Export:
+      Name: !Sub "${AWS::Region}-${AWS::StackName}-CredentialsSecretName"
+    Description: Name of the Secrets Manager secret for encrypted Synapse credentials
+    Value: !Ref SynapseCredentialsSecret

--- a/templates/bucket-replication-lambda.yaml
+++ b/templates/bucket-replication-lambda.yaml
@@ -61,7 +61,7 @@ Parameters:
     Description: >
       Comma-delimited list of numeric Synapse user IDs to be notified when an attempt to sync to Synapse is made
       by the Lambda function. Example: the `ownerId` returned by a call to the Synapse REST API /userProfile.
-  ReplicationSourceAccountId:
+  SourceAccountId:
     Type: Number
     Description: ID of the AWS account holding the replication source bucket.
   SynapseAWSAccountId:
@@ -313,7 +313,7 @@ Resources:
           - Sid: SourceAccount1
             Effect: Allow
             Principal:
-              AWS: !Sub arn:aws:iam::${ReplicationSourceAccountId}:root
+              AWS: !Sub arn:aws:iam::${SourceAccountId}:root
             Action:
               - s3:GetBucketVersioning
               - s3:PutBucketVersioning

--- a/templates/bucket-replication-lambda.yaml
+++ b/templates/bucket-replication-lambda.yaml
@@ -1,0 +1,203 @@
+# This template creates an S3 bucket and a Lambda function
+#
+# The S3 bucket is granted permissions to be a Synapse storage location, *and* an S3 replication destination
+# from a collaborator's AWS account.
+#
+# The Lambda function is triggered by PUT requests to the bucket. It reads the files, computes and writes md5 sums
+# back to the bucket, and adds file handles to Synapse.
+#
+# This stack will need to be created with SynapseStorageLocationId = "" (blank). After the bucket is created,
+# the Synapse storage location must be created externally. Then update the stack with the new value for
+# SynapseStorageLocationId.
+#
+
+AWSTemplateFormatVersion: "2010-09-09"
+
+Parameters:
+  FunctionName:
+    Type: String
+    Description: Name of lambda function
+  FunctionCodeBucket:
+    Type: String
+    Description: S3 bucket where lambda deployment package is stored
+  FunctionCodePrefix:
+    Type: String
+    Description: Prefix, not including filename, of the directory in S3 where code is stored
+  FunctionCodeKey:
+    Type: String
+    Description: S3 key of lambda deployment package file
+  SynapseUsername:
+    Type: String
+    Description: Synapse username used to create files in Synapse.
+  SynapseApikey:
+    Type: String
+    Description: Synapse API key (associated with SynapseUsername) used to authenticate to Synapse.
+  SynapseStorageLocationId:
+    Type: Number
+    Description: >
+      Integer location ID for the bucket containing the files to be added to Synapse. Note a blank value should
+      be provided the when the stack is created.
+      See https://docs.synapse.org/articles/custom_storage_location.html
+  SynapseNotifyUsers:
+    Type: String
+    Description: >
+      Comma-delimited list of numeric Synapse user IDs to be notified when an attempt to sync to Synapse is made
+      by the Lambda function. Example: the `ownerId` returned by a call to the Synapse REST API /userProfile.
+  ReplicationSourceAccountId:
+    Type: Number
+    Description: ID of the AWS account holding the replication source bucket.
+  SynapseAWSAccountId:
+    Type: Number
+    Description: >
+      ID of the Synapse AWS account. Used for allowing Synapse to access the DataBucket as an external storage location.
+      See https://docs.synapse.org/articles/custom_storage_location.html
+    Default: 325565585839
+  Md5BlockSize:
+    Type: Number
+    Default: 5242880 # 5 MB
+    Description:
+      Maximum block size allocated to computing MD5 sums, in bytes.
+
+Resources:
+
+  LambdaExecutionRole:
+    Type: AWS::IAM::Role
+    Properties:
+      #Description: ARN of role that lambda uses for execution.
+      RoleName: !Sub ${AWS::StackName}-LambdaExecutionRole
+      AssumeRolePolicyDocument:
+        Statement:
+          - Action: ['sts:AssumeRole']
+            Effect: Allow
+            Principal:
+              Service: [lambda.amazonaws.com]
+
+  LambdaExecutionRolePolicy:
+    Type: AWS::IAM::Policy
+    Properties:
+      #Description: Allows access to the S3 data bucket and CloudWatch logs.
+      PolicyName: !Sub ${AWS::StackName}-LambdaExecutionPolicy
+      Roles: [!Ref 'LambdaExecutionRole']
+      PolicyDocument:
+        Statement:
+          - Effect: Allow
+            Action:
+              - logs:CreateLogGroup
+              - logs:CreateLogStream
+              - logs:PutLogEvents
+            Resource: "*"
+          - Effect: Allow
+            Action:
+              - s3:ListBucket
+            Resource:
+              - !Join
+                - ""
+                - - "arn:aws:s3:::"
+                  - !Sub ${AWS::StackName}-data
+            Sid: VisualEditor1
+          - Effect: Allow
+            Action:
+              - s3:PutObject
+              - s3:GetObject
+            Resource:
+              - !Join
+                - ""
+                - - "arn:aws:s3:::"
+                  - !Sub ${AWS::StackName}-data
+                  - "/*"
+
+  BucketToSynapseFunction:
+    Type: AWS::Lambda::Function
+    Properties:
+      FunctionName: !Ref FunctionName
+      Code:
+        S3Bucket: !Ref FunctionCodeBucket
+        S3Key: !Ref FunctionCodeKey
+      Description: Adds files from an S3 bucket to Synapse.
+      Environment:
+        Variables:
+          SYNAPSE_USERNAME: !Ref SynapseUsername
+          SYNAPSE_APIKEY: !Ref SynapseApikey
+          SYNAPSE_SOURCE_BUCKET_STORAGE_LOCATION_ID: !Ref SynapseStorageLocationId
+          SYNAPSE_NOTIFY_USERS: !Ref SynapseNotifyUsers
+          MD5_BLOCK_SIZE: !Ref Md5BlockSize
+      Handler: lambda_function.lambda_handler
+      Runtime: python3.7
+      Timeout: 300
+      Role: !GetAtt LambdaExecutionRole.Arn
+
+  DataBucket:
+    Type: AWS::S3::Bucket
+    DeletionPolicy: Delete
+    DependsOn:
+      - LambdaExecutionRolePolicy
+    Properties:
+      BucketName: !Sub ${AWS::StackName}-data
+      VersioningConfiguration:
+        Status: Enabled
+      NotificationConfiguration:
+        LambdaConfigurations:
+          - Event: s3:ObjectCreated:*
+            Function: !GetAtt [BucketToSynapseFunction, Arn]
+
+  BucketPermission:
+    Type: AWS::Lambda::Permission
+    Properties:
+      Action: 'lambda:InvokeFunction'
+      FunctionName: !Ref BucketToSynapseFunction
+      Principal: s3.amazonaws.com
+      SourceAccount: !Ref 'AWS::AccountId'
+      SourceArn: !Join
+          - ""
+          - - "arn:aws:s3:::"
+            - !Sub ${AWS::StackName}-data
+
+  BucketPolicy:
+    Type: AWS::S3::BucketPolicy
+    Properties:
+      Bucket: !Ref DataBucket
+      PolicyDocument:
+        Version: '2008-10-17'
+        Id: PolicyForDestinationBucket
+        Statement:
+          # Allow Synapse to access the data bucket
+          - Sid: Synapse1
+            Principal:
+              AWS: !Sub "arn:aws:iam::${SynapseAWSAccountId}:root"
+            Action:
+              - "s3:ListBucket*"
+              - "s3:GetBucketLocation"
+            Resource: !GetAtt
+              - DataBucket
+              - Arn
+            Effect: 'Allow'
+          - Sid: Synapse2
+            Principal:
+              AWS: !Sub "arn:aws:iam::${SynapseAWSAccountId}:root"
+            Action:
+              - "s3:GetObject*"
+              - "s3:*MultipartUpload*"
+            Resource: !Join [ "", [!GetAtt [DataBucket, Arn], "/*"]]
+            Effect: "Allow"
+          # Allow the source bucket to write to the data bucket
+          - Sid: !Sub SourceAccount1
+            Effect: Allow
+            Principal:
+              AWS: !Sub arn:aws:iam::${ReplicationSourceAccountId}:root
+            Action:
+              - s3:GetBucketVersioning
+              - s3:ReplicateObject
+              - s3:ReplicateDelete
+              - s3:ObjectOwnerOverrideToBucketOwner
+            Resource:
+              - !GetAtt [DataBucket, Arn]
+              - !Join [ "", [!GetAtt [DataBucket, Arn], "/*"]]
+
+
+Outputs:
+  BucketToSynapseFunctionArn:
+    Description: ARN of the lambda function that was created in this template.
+    Value: !GetAtt BucketToSynapseFunction.Arn
+  DataBucketArn:
+    Description: ARN of the data bucket that was created
+    Value: !GetAtt DataBucket.Arn

--- a/templates/bucket-replication-lambda.yaml
+++ b/templates/bucket-replication-lambda.yaml
@@ -177,8 +177,12 @@ Resources:
 
 Outputs:
   BucketToSynapseFunctionArn:
+    Export:
+      Name: !Sub "${AWS::Region}-${AWS::StackName}-BucketToSynapseFunctionArn"
     Description: ARN of the lambda function that was created in this template.
     Value: !GetAtt BucketToSynapseFunction.Arn
   DataBucketArn:
+    Export:
+      Name: !Sub "${AWS::Region}-${AWS::StackName}-DataBucketArn"
     Description: ARN of the data bucket that was created
     Value: !GetAtt DataBucket.Arn

--- a/templates/bucket-replication-lambda.yaml
+++ b/templates/bucket-replication-lambda.yaml
@@ -14,9 +14,6 @@
 AWSTemplateFormatVersion: "2010-09-09"
 
 Parameters:
-  FunctionName:
-    Type: String
-    Description: Name of lambda function
   FunctionCodeBucket:
     Type: String
     Description: S3 bucket where lambda deployment package is stored
@@ -61,7 +58,6 @@ Resources:
     Type: AWS::IAM::Role
     Properties:
       #Description: ARN of role that lambda uses for execution.
-      RoleName: !Sub ${AWS::StackName}-LambdaExecutionRole
       AssumeRolePolicyDocument:
         Statement:
           - Action: ['sts:AssumeRole']
@@ -73,7 +69,6 @@ Resources:
     Type: AWS::IAM::Policy
     Properties:
       #Description: Allows access to the S3 data bucket and CloudWatch logs.
-      PolicyName: !Sub ${AWS::StackName}-LambdaExecutionPolicy
       Roles: [!Ref 'LambdaExecutionRole']
       PolicyDocument:
         Statement:
@@ -87,26 +82,18 @@ Resources:
             Action:
               - s3:ListBucket
             Resource:
-              - !Join
-                - ""
-                - - "arn:aws:s3:::"
-                  - !Sub ${AWS::StackName}-data
+              - !Sub "arn:aws:s3:::${AWS::StackName}-data"
             Sid: VisualEditor1
           - Effect: Allow
             Action:
               - s3:PutObject
               - s3:GetObject
             Resource:
-              - !Join
-                - ""
-                - - "arn:aws:s3:::"
-                  - !Sub ${AWS::StackName}-data
-                  - "/*"
+              - !Sub "arn:aws:s3:::${AWS::StackName}-data/*"
 
   BucketToSynapseFunction:
     Type: AWS::Lambda::Function
     Properties:
-      FunctionName: !Ref FunctionName
       Code:
         S3Bucket: !Ref FunctionCodeBucket
         S3Key: !Ref FunctionCodeKey
@@ -144,10 +131,7 @@ Resources:
       FunctionName: !Ref BucketToSynapseFunction
       Principal: s3.amazonaws.com
       SourceAccount: !Ref 'AWS::AccountId'
-      SourceArn: !Join
-          - ""
-          - - "arn:aws:s3:::"
-            - !Sub ${AWS::StackName}-data
+      SourceArn: !Sub "arn:aws:s3:::${AWS::StackName}-data"
 
   BucketPolicy:
     Type: AWS::S3::BucketPolicy

--- a/templates/bucket-replication-lambda.yaml
+++ b/templates/bucket-replication-lambda.yaml
@@ -75,6 +75,21 @@ Parameters:
     Default: 5242880 # 5 MB
     Description:
       Maximum block size allocated to computing MD5 sums, in bytes.
+  Department:
+    Description: 'The department for this resource'
+    Type: String
+    AllowedPattern: '^\S*$'
+    ConstraintDescription: 'Must be string with no spaces'
+  Project:
+    Description: 'The name of the project that this resource is used for'
+    Type: String
+    AllowedPattern: '^\S*$'
+    ConstraintDescription: 'Must be string with no spaces'
+  OwnerEmail:
+    Description: 'Email address of the owner of this resource'
+    Type: String
+    AllowedPattern: '^(([^<>()\[\]\\.,;:\s@"]+(\.[^<>()\[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$'
+    ConstraintDescription: 'Must be an acceptable email address syntax(i.e. joe.smith@sagebase.org)'
 
 Mappings:
   AdminRoleArns:
@@ -129,13 +144,13 @@ Resources:
             Resource: "*"
             # TODO: Allow lambda to decrypt only; allow other user(s) to encrypt
             # TODO tags on everything
-#      Tags:
-#        - Key: "Department"
-#          Value: !Ref Department
-#        - Key: "Project"
-#          Value: !Ref Project
-#        - Key: "OwnerEmail"
-#          Value: !Ref OwnerEmail
+      Tags:
+        - Key: Department
+          Value: !Ref Department
+        - Key: Project
+          Value: !Ref Project
+        - Key: OwnerEmail
+          Value: !Ref OwnerEmail
 
   KmsKeyAlias:
     Type: AWS::KMS::Alias
@@ -153,6 +168,13 @@ Resources:
             Effect: Allow
             Principal:
               Service: [lambda.amazonaws.com]
+      Tags:
+        - Key: Department
+          Value: !Ref Department
+        - Key: Project
+          Value: !Ref Project
+        - Key: OwnerEmail
+          Value: !Ref OwnerEmail
 
   LambdaExecutionRolePolicy:
     Type: AWS::IAM::Policy
@@ -195,6 +217,13 @@ Resources:
       KmsKeyId: !Ref KmsKey
       # Need explicit name so that it can be referenced by the Lambda function
       Name: !Sub "${AWS::Region}-${AWS::StackName}-SynapseCredentialsSecret"
+      Tags:
+        - Key: Department
+          Value: !Ref Department
+        - Key: Project
+          Value: !Ref Project
+        - Key: OwnerEmail
+          Value: !Ref OwnerEmail
 
   BucketToSynapseFunction:
     Type: AWS::Lambda::Function
@@ -214,6 +243,13 @@ Resources:
       Runtime: python3.7
       Timeout: 300
       Role: !GetAtt LambdaExecutionRole.Arn
+      Tags:
+        - Key: Department
+          Value: !Ref Department
+        - Key: Project
+          Value: !Ref Project
+        - Key: OwnerEmail
+          Value: !Ref OwnerEmail
 
   DataBucket:
     Type: AWS::S3::Bucket
@@ -229,6 +265,13 @@ Resources:
         LambdaConfigurations:
           - Event: s3:ObjectCreated:*
             Function: !GetAtt [BucketToSynapseFunction, Arn]
+      Tags:
+        - Key: Department
+          Value: !Ref Department
+        - Key: Project
+          Value: !Ref Project
+        - Key: OwnerEmail
+          Value: !Ref OwnerEmail
 
   BucketPermission:
     Type: AWS::Lambda::Permission
@@ -280,7 +323,6 @@ Resources:
             Resource:
               - !GetAtt [DataBucket, Arn]
               - !Join [ "", [!GetAtt [DataBucket, Arn], "/*"]]
-
 
 Outputs:
   BucketToSynapseFunctionArn:

--- a/templates/bucket-replication-lambda.yaml
+++ b/templates/bucket-replication-lambda.yaml
@@ -20,9 +20,6 @@ Parameters:
   FunctionCodeBucket:
     Type: String
     Description: S3 bucket where lambda deployment package is stored
-  FunctionCodePrefix:
-    Type: String
-    Description: Prefix, not including filename, of the directory in S3 where code is stored
   FunctionCodeKey:
     Type: String
     Description: S3 key of lambda deployment package file
@@ -157,7 +154,7 @@ Resources:
     Properties:
       Bucket: !Ref DataBucket
       PolicyDocument:
-        Version: '2008-10-17'
+        Version: '2012-10-17'
         Id: PolicyForDestinationBucket
         Statement:
           # Allow Synapse to access the data bucket
@@ -180,7 +177,7 @@ Resources:
             Resource: !Join [ "", [!GetAtt [DataBucket, Arn], "/*"]]
             Effect: "Allow"
           # Allow the source bucket to write to the data bucket
-          - Sid: !Sub SourceAccount1
+          - Sid: SourceAccount1
             Effect: Allow
             Principal:
               AWS: !Sub arn:aws:iam::${ReplicationSourceAccountId}:root

--- a/templates/ecmonsen-emorypipeline.yaml
+++ b/templates/ecmonsen-emorypipeline.yaml
@@ -1,0 +1,107 @@
+Description: Setup service account and roles for Emory pipeline lambda
+AWSTemplateFormatVersion: 2010-09-09
+
+Parameters:
+  Department:
+    Description: 'The department for this resource'
+    Type: String
+    AllowedPattern: '^\S*$'
+    ConstraintDescription: 'Must be string with no spaces'
+    Default: 'SysBio'
+  Project:
+    Description: 'The name of the project that this resource is used for'
+    Type: String
+    AllowedPattern: '^\S*$'
+    ConstraintDescription: 'Must be string with no spaces'
+    Default: 'AMP-AD'
+  OwnerEmail:
+    Description: 'Email address of the owner of this resource'
+    Type: String
+    AllowedPattern: '^(([^<>()\[\]\\.,;:\s@"]+(\.[^<>()\[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$'
+    ConstraintDescription: 'Must be an acceptable email address syntax(i.e. joe.smith@sagebase.org)'
+    Default: 'eva.monsen@sagebase.org'
+
+Resources:
+  # !! IMPORTANT !! - AWS API will refuse to remove users that have attached resources.
+  # Therefore you must do the following before deleting them from this file:
+  # 1. Detach or remove the following user resources: login profile, attached
+  #    MFA device, access-keys, ssh-keys, and policies.
+  # 2. Detach the user from all groups.
+  LambdaArtifactsBucket:
+    Type: 'AWS::S3::Bucket'
+    Properties:
+      Tags:
+        - Key: "Department"
+          Value: !Ref Department
+        - Key: "Project"
+          Value: !Ref Project
+        - Key: "OwnerEmail"
+          Value: !Ref OwnerEmail
+
+  CfnDeployerServiceUser:
+    Type: 'AWS::IAM::User'
+  CfnDeployerServiceUserAccessKey:
+    Type: 'AWS::IAM::AccessKey'
+    Properties:
+      UserName: !Ref CfnDeployerServiceUser
+  CfnDeployerServiceRole:
+    Type: "AWS::IAM::Role"
+    Properties:
+      Path: "/"
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: "Allow"
+            Principal:
+              AWS:
+                - !GetAtt CfnDeployerServiceUser.Arn
+            Action:
+              - "sts:AssumeRole"
+  CfnDeployerServiceRolePolicy:
+    Type: "AWS::IAM::Policy"
+    Properties:
+      PolicyName: "deployer"
+      Roles:
+        - !Ref CfnDeployerServiceRole
+      PolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Sid: "LambdaArtifactsBucketFullAccess"
+            Action:
+              - s3:*
+            Effect: Allow
+            Resource: !GetAtt LambdaArtifactsBucket.Arn
+
+Outputs:
+  LambdaArtifactsBucketName:
+    Value: !Ref LambdaArtifactsBucket
+    Export:
+      Name: !Sub '${AWS::Region}-${AWS::StackName}-LambdaArtifactsBucketName'
+  LambdaArtifactsBucketArn:
+    Value: !GetAtt LambdaArtifactsBucket.Arn
+    Export:
+      Name: !Sub '${AWS::Region}-${AWS::StackName}-LambdaArtifactsBucketArn'
+  CfnDeployerServiceUser:
+    Value: !Ref CfnDeployerServiceUser
+    Export:
+      Name: !Sub '${AWS::Region}-${AWS::StackName}-CfnDeployerServiceUser'
+  CfnDeployerServiceUserArn:
+    Value: !GetAtt CfnDeployerServiceUser.Arn
+    Export:
+      Name: !Sub '${AWS::Region}-${AWS::StackName}-CfnDeployerServiceUserArn'
+  CfnDeployerServiceUserAccessKey:
+    Value: !Ref CfnDeployerServiceUserAccessKey
+    Export:
+      Name: !Sub '${AWS::Region}-${AWS::StackName}-CfnDeployerServiceUserAccessKey'
+  CfnDeployerServiceUserSecretAccessKey:
+    Value: !GetAtt CfnDeployerServiceUserAccessKey.SecretAccessKey
+    Export:
+      Name: !Sub '${AWS::Region}-${AWS::StackName}-CfnDeployerServiceUserSecretAccessKey'
+  CfnDeployerServiceRole:
+    Value: !Ref CfnDeployerServiceRole
+    Export:
+      Name: !Sub '${AWS::Region}-${AWS::StackName}-CfnDeployerServiceRole'
+  CfnDeployerServiceRoleArn:
+    Value: !GetAtt CfnDeployerServiceRole.Arn
+    Export:
+      Name: !Sub '${AWS::Region}-${AWS::StackName}-CfnDeployerServiceRoleArn'


### PR DESCRIPTION
This template creates resources needed for the Emory data pipeline. Placing in Sandbox for testing; ultimately it will need to be deployed to SciComp.

* a bucket that will be the [S3 bucket replication](https://docs.aws.amazon.com/AmazonS3/latest/dev/replication.html) destination. (The source is an Emory-owned bucket which Emory will manage.) This bucket will also be a Synapse external storage location.
* a Lambda function that will be triggered upon PUTs to the bucket. When a file is PUT, the Lambda will compute the md5, add some Synapse annotations and provenance, and add a file handle to Synapse.

Some questions that I'll probably need help answering before this is merged:

In order to deploy the template in this PR you will need a set of parameters to pass to CloudFormation such as the location of the Lambda code, etc. Where should I put them? Some parameters are sensitive such as a Synapse API key that the Lambda will use to authenticate to Synapse. 

While creating this PR I noticed that there is a template for requesting an S3 bucket only. Please let me know if I should create one of those requests for the bucket. But note that most of this CF template (permissions for replication, Lambda trigger) will still need to be applied to the new bucket, and it's much easier to do bucket creation and all the other stuff in the same template.

I would also need to be able to update the Lambda code as I fix issues during testing. I'm not clear on the process for this - can I use my own IAM user to do it?

