### PR TITLE
update references to ecmonsen lambda

### DIFF
--- a/config/prod/ecmonsen-emorypipeline-lambda.yaml
+++ b/config/prod/ecmonsen-emorypipeline-lambda.yaml
@@ -19,6 +19,6 @@ hooks:
     #
     # Note the "master" branch always contains the latest successful build. When deploying to production the path
     # should be changed to use "vX.X.X" to deploy from tag vX.X.X
-    - !cmd curl https://ecmonsen-emorypipeline-ci-lambdaartifactsbucket-nu5xkcp8vax4.s3.amazonaws.com/lambda-uploader/master/ecmonsen-emorypipeline-lambda.yaml --create-dirs -o templates/remote/ecmonsen-emorypipeline-lambda.yaml
+    - !cmd curl https://ecmonsen-emorypipeline-ci-lambdaartifactsbucket-jnlt9zs4haa7.s3.amazonaws.com/lambda-uploader/master/ecmonsen-emorypipeline-lambda.yaml --create-dirs -o templates/remote/ecmonsen-emorypipeline-lambda.yaml
   before_update:
-    - !cmd curl https://ecmonsen-emorypipeline-ci-lambdaartifactsbucket-nu5xkcp8vax4.s3.amazonaws.com/lambda-uploader/master/ecmonsen-emorypipeline-lambda.yaml --create-dirs -o templates/remote/ecmonsen-emorypipeline-lambda.yaml
+    - !cmd curl https://ecmonsen-emorypipeline-ci-lambdaartifactsbucket-jnlt9zs4haa7.s3.amazonaws.com/lambda-uploader/master/ecmonsen-emorypipeline-lambda.yaml --create-dirs -o templates/remote/ecmonsen-emorypipeline-lambda.yaml


### PR DESCRIPTION
The ecmonsen-emorypipeline-lambda-code[1] was previously being deployed
to a bucket in org-sagebase-sandbox account.  We have now changed it to
deploy to a bucket in org-sagebase-scicomp account.  Also a new version
was created.  Redirect references to the new bucket.

[1] https://github.com/Sage-Bionetworks/ecmonsen-emorypipeline-lambda-code
