### PR TITLE
IT-790: New S3 URL Formatting

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,19 +1,19 @@
 repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v2.3.0
+    rev: v3.1.0
     hooks:
     -   id: end-of-file-fixer
     -   id: trailing-whitespace
 -   repo: https://github.com/adrienverge/yamllint
-    rev: v1.17.0
+    rev: v1.23.0
     hooks:
     -   id: yamllint
 -   repo: https://github.com/awslabs/cfn-python-lint
-    rev: v0.23.3
+    rev: v0.33.0
     hooks:
     -   id: cfn-python-lint
         files: templates/.*\.(json|yml|yaml)$
 -   repo: https://github.com/Lucas-C/pre-commit-hooks
-    rev: v1.1.6
+    rev: v1.1.7
     hooks:
     -   id: remove-tabs

--- a/config/prod/JKG-s3.yaml
+++ b/config/prod/JKG-s3.yaml
@@ -18,9 +18,7 @@ parameters:
     - 'arn:aws:iam::563295687221:user/jake.gockley@sagebase.org'
 
 hooks:
-  before_create:
-    - !cmd "curl https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/aws-infra/master/s3-bucket.yaml --create-dirs -o templates/remote/s3-bucket.yaml"
-  before_update:
+  before_launch:
     - !cmd "curl https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/aws-infra/master/s3-bucket.yaml --create-dirs -o templates/remote/s3-bucket.yaml"
   after_create:
     - !s3_notify "{{stack_group_config.aws_account_name}} {{stack_group_config.aws_account_email}}"

--- a/config/prod/JKG-s3.yaml
+++ b/config/prod/JKG-s3.yaml
@@ -19,6 +19,6 @@ parameters:
 
 hooks:
   before_launch:
-    - !cmd "curl https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/aws-infra/master/s3-bucket.yaml --create-dirs -o templates/remote/s3-bucket.yaml"
+    - !cmd "curl https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/s3-bucket.yaml --create-dirs -o templates/remote/s3-bucket.yaml"
   after_create:
     - !s3_notify "{{stack_group_config.aws_account_name}} {{stack_group_config.aws_account_email}}"

--- a/config/prod/ahayden-testhost-lin.yaml
+++ b/config/prod/ahayden-testhost-lin.yaml
@@ -27,6 +27,6 @@ parameters:
 # For CI system (do not change)
 hooks:
   before_launch:
-    - !cmd "curl https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/aws-infra/master/managed-ec2-linux-v1.j2 --create-dirs -o templates/remote/managed-ec2-linux-v1.j2"
+    - !cmd "curl https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/managed-ec2-linux-v1.j2 --create-dirs -o templates/remote/managed-ec2-linux-v1.j2"
   after_create:
     - !ec2_notify "{{stack_group_config.aws_account_name}} {{stack_group_config.aws_account_email}}"

--- a/config/prod/ahayden-testhost-lin.yaml
+++ b/config/prod/ahayden-testhost-lin.yaml
@@ -26,9 +26,7 @@ parameters:
 
 # For CI system (do not change)
 hooks:
-  before_create:
-    - !cmd "curl https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/aws-infra/master/managed-ec2-linux-v1.j2 --create-dirs -o templates/remote/managed-ec2-linux-v1.j2"
-  before_update:
+  before_launch:
     - !cmd "curl https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/aws-infra/master/managed-ec2-linux-v1.j2 --create-dirs -o templates/remote/managed-ec2-linux-v1.j2"
   after_create:
     - !ec2_notify "{{stack_group_config.aws_account_name}} {{stack_group_config.aws_account_email}}"

--- a/config/prod/ahayden-testhost-win.yaml
+++ b/config/prod/ahayden-testhost-win.yaml
@@ -40,6 +40,6 @@ parameters:
 # For CI system (do not change)
 hooks:
   before_launch:
-    - !cmd "curl https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/aws-infra/master/managed-ec2-win-v4.j2 --create-dirs -o templates/remote/managed-ec2-win-v4.j2"
+    - !cmd "curl https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/managed-ec2-win-v4.j2 --create-dirs -o templates/remote/managed-ec2-win-v4.j2"
   after_create:
     - !ec2_notify "{{stack_group_config.aws_account_name}} {{stack_group_config.aws_account_email}}"

--- a/config/prod/ahayden-testhost-win.yaml
+++ b/config/prod/ahayden-testhost-win.yaml
@@ -39,9 +39,7 @@ parameters:
 
 # For CI system (do not change)
 hooks:
-  before_create:
-    - !cmd "curl https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/aws-infra/master/managed-ec2-win-v4.j2 --create-dirs -o templates/remote/managed-ec2-win-v4.j2"
-  before_update:
+  before_launch:
     - !cmd "curl https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/aws-infra/master/managed-ec2-win-v4.j2 --create-dirs -o templates/remote/managed-ec2-win-v4.j2"
   after_create:
     - !ec2_notify "{{stack_group_config.aws_account_name}} {{stack_group_config.aws_account_email}}"

--- a/config/prod/arvados-wf-testing.yaml
+++ b/config/prod/arvados-wf-testing.yaml
@@ -40,9 +40,7 @@ parameters:
 
 # For CI system (do not change)
 hooks:
-  before_create:
-    - !cmd "curl https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/aws-infra/master/managed-ec2-linux-v1.j2 --create-dirs -o templates/remote/managed-ec2-linux-v1.j2"
-  before_update:
+  before_launch:
     - !cmd "curl https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/aws-infra/master/managed-ec2-linux-v1.j2 --create-dirs -o templates/remote/managed-ec2-linux-v1.j2"
   after_create:
     - !ec2_notify "{{stack_group_config.aws_account_name}} {{stack_group_config.aws_account_email}}"

--- a/config/prod/arvados-wf-testing.yaml
+++ b/config/prod/arvados-wf-testing.yaml
@@ -41,6 +41,6 @@ parameters:
 # For CI system (do not change)
 hooks:
   before_launch:
-    - !cmd "curl https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/aws-infra/master/managed-ec2-linux-v1.j2 --create-dirs -o templates/remote/managed-ec2-linux-v1.j2"
+    - !cmd "curl https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/managed-ec2-linux-v1.j2 --create-dirs -o templates/remote/managed-ec2-linux-v1.j2"
   after_create:
     - !ec2_notify "{{stack_group_config.aws_account_name}} {{stack_group_config.aws_account_email}}"

--- a/config/prod/bwhite-beat-aml-bioc-again.yaml
+++ b/config/prod/bwhite-beat-aml-bioc-again.yaml
@@ -40,9 +40,7 @@ parameters:
 
 # For CI system (do not change)
 hooks:
-  before_create:
-    - !cmd "curl https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/aws-infra/master/managed-ec2-linux-v1.j2 --create-dirs -o templates/remote/managed-ec2-linux-v1.j2"
-  before_update:
+  before_launch:
     - !cmd "curl https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/aws-infra/master/managed-ec2-linux-v1.j2 --create-dirs -o templates/remote/managed-ec2-linux-v1.j2"
   after_create:
     - !ec2_notify "{{stack_group_config.aws_account_name}} {{stack_group_config.aws_account_email}}"

--- a/config/prod/bwhite-beat-aml-bioc-again.yaml
+++ b/config/prod/bwhite-beat-aml-bioc-again.yaml
@@ -41,6 +41,6 @@ parameters:
 # For CI system (do not change)
 hooks:
   before_launch:
-    - !cmd "curl https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/aws-infra/master/managed-ec2-linux-v1.j2 --create-dirs -o templates/remote/managed-ec2-linux-v1.j2"
+    - !cmd "curl https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/managed-ec2-linux-v1.j2 --create-dirs -o templates/remote/managed-ec2-linux-v1.j2"
   after_create:
     - !ec2_notify "{{stack_group_config.aws_account_name}} {{stack_group_config.aws_account_email}}"

--- a/config/prod/bwhite-beat-aml-bioc.yaml
+++ b/config/prod/bwhite-beat-aml-bioc.yaml
@@ -42,6 +42,6 @@ parameters:
 # For CI system (do not change)
 hooks:
   before_launch:
-    - !cmd "curl https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/aws-infra/master/managed-ec2-ubuntu-v3.j2 --create-dirs -o templates/remote/managed-ec2-ubuntu-v3.j2"
+    - !cmd "curl https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/managed-ec2-ubuntu-v3.j2 --create-dirs -o templates/remote/managed-ec2-ubuntu-v3.j2"
   after_create:
     - !ec2_notify "{{stack_group_config.aws_account_name}} {{stack_group_config.aws_account_email}}"

--- a/config/prod/bwhite-beat-aml-bioc.yaml
+++ b/config/prod/bwhite-beat-aml-bioc.yaml
@@ -41,9 +41,7 @@ parameters:
 
 # For CI system (do not change)
 hooks:
-  before_create:
-    - !cmd "curl https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/aws-infra/master/managed-ec2-ubuntu-v3.j2 --create-dirs -o templates/remote/managed-ec2-ubuntu-v3.j2"
-  before_update:
+  before_launch:
     - !cmd "curl https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/aws-infra/master/managed-ec2-ubuntu-v3.j2 --create-dirs -o templates/remote/managed-ec2-ubuntu-v3.j2"
   after_create:
     - !ec2_notify "{{stack_group_config.aws_account_name}} {{stack_group_config.aws_account_email}}"

--- a/config/prod/bwhite-iawg.yaml
+++ b/config/prod/bwhite-iawg.yaml
@@ -42,6 +42,6 @@ parameters:
 # For CI system (do not change)
 hooks:
   before_launch:
-    - !cmd "curl https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/aws-infra/master/managed-ec2-linux-v1.j2 --create-dirs -o templates/remote/managed-ec2-linux-v1.j2"
+    - !cmd "curl https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/managed-ec2-linux-v1.j2 --create-dirs -o templates/remote/managed-ec2-linux-v1.j2"
   after_create:
     - !ec2_notify "{{stack_group_config.aws_account_name}} {{stack_group_config.aws_account_email}}"

--- a/config/prod/bwhite-iawg.yaml
+++ b/config/prod/bwhite-iawg.yaml
@@ -41,9 +41,7 @@ parameters:
 
 # For CI system (do not change)
 hooks:
-  before_create:
-    - !cmd "curl https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/aws-infra/master/managed-ec2-linux-v1.j2 --create-dirs -o templates/remote/managed-ec2-linux-v1.j2"
-  before_update:
+  before_launch:
     - !cmd "curl https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/aws-infra/master/managed-ec2-linux-v1.j2 --create-dirs -o templates/remote/managed-ec2-linux-v1.j2"
   after_create:
     - !ec2_notify "{{stack_group_config.aws_account_name}} {{stack_group_config.aws_account_email}}"

--- a/config/prod/bwhite-novartis-cml-bioc.yaml
+++ b/config/prod/bwhite-novartis-cml-bioc.yaml
@@ -42,6 +42,6 @@ parameters:
 # For CI system (do not change)
 hooks:
   before_launch:
-    - !cmd "curl https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/aws-infra/master/managed-ec2-ubuntu-v3.j2 --create-dirs -o templates/remote/managed-ec2-ubuntu-v3.j2"
+    - !cmd "curl https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/managed-ec2-ubuntu-v3.j2 --create-dirs -o templates/remote/managed-ec2-ubuntu-v3.j2"
   after_create:
     - !ec2_notify "{{stack_group_config.aws_account_name}} {{stack_group_config.aws_account_email}}"

--- a/config/prod/bwhite-novartis-cml-bioc.yaml
+++ b/config/prod/bwhite-novartis-cml-bioc.yaml
@@ -41,9 +41,7 @@ parameters:
 
 # For CI system (do not change)
 hooks:
-  before_create:
-    - !cmd "curl https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/aws-infra/master/managed-ec2-ubuntu-v3.j2 --create-dirs -o templates/remote/managed-ec2-ubuntu-v3.j2"
-  before_update:
+  before_launch:
     - !cmd "curl https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/aws-infra/master/managed-ec2-ubuntu-v3.j2 --create-dirs -o templates/remote/managed-ec2-ubuntu-v3.j2"
   after_create:
     - !ec2_notify "{{stack_group_config.aws_account_name}} {{stack_group_config.aws_account_email}}"

--- a/config/prod/bwhite-novartis-cml.yaml
+++ b/config/prod/bwhite-novartis-cml.yaml
@@ -42,6 +42,6 @@ parameters:
 # For CI system (do not change)
 hooks:
   before_launch:
-    - !cmd "curl https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/aws-infra/master/managed-ec2-ubuntu-v3.j2 --create-dirs -o templates/remote/managed-ec2-ubuntu-v3.j2"
+    - !cmd "curl https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/managed-ec2-ubuntu-v3.j2 --create-dirs -o templates/remote/managed-ec2-ubuntu-v3.j2"
   after_create:
     - !ec2_notify "{{stack_group_config.aws_account_name}} {{stack_group_config.aws_account_email}}"

--- a/config/prod/bwhite-novartis-cml.yaml
+++ b/config/prod/bwhite-novartis-cml.yaml
@@ -41,9 +41,7 @@ parameters:
 
 # For CI system (do not change)
 hooks:
-  before_create:
-    - !cmd "curl https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/aws-infra/master/managed-ec2-ubuntu-v3.j2 --create-dirs -o templates/remote/managed-ec2-ubuntu-v3.j2"
-  before_update:
+  before_launch:
     - !cmd "curl https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/aws-infra/master/managed-ec2-ubuntu-v3.j2 --create-dirs -o templates/remote/managed-ec2-ubuntu-v3.j2"
   after_create:
     - !ec2_notify "{{stack_group_config.aws_account_name}} {{stack_group_config.aws_account_email}}"

--- a/config/prod/dgutman-htan-ec2.yaml
+++ b/config/prod/dgutman-htan-ec2.yaml
@@ -39,6 +39,6 @@ parameters:
 # For CI system (do not change)
 hooks:
   before_launch:
-    - !cmd "curl https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/aws-infra/master/managed-ec2-v7.yaml --create-dirs -o templates/remote/managed-ec2.yaml"
+    - !cmd "curl https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/managed-ec2-v7.yaml --create-dirs -o templates/remote/managed-ec2.yaml"
   after_create:
     - !ec2_notify "{{stack_group_config.aws_account_name}} {{stack_group_config.aws_account_email}}"

--- a/config/prod/dgutman-htan-ec2.yaml
+++ b/config/prod/dgutman-htan-ec2.yaml
@@ -38,9 +38,7 @@ parameters:
 
 # For CI system (do not change)
 hooks:
-  before_create:
-    - !cmd "curl https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/aws-infra/master/managed-ec2-v7.yaml --create-dirs -o templates/remote/managed-ec2.yaml"
-  before_update:
+  before_launch:
     - !cmd "curl https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/aws-infra/master/managed-ec2-v7.yaml --create-dirs -o templates/remote/managed-ec2.yaml"
   after_create:
     - !ec2_notify "{{stack_group_config.aws_account_name}} {{stack_group_config.aws_account_email}}"

--- a/config/prod/dgutman-htan-new2-ec2.yaml
+++ b/config/prod/dgutman-htan-new2-ec2.yaml
@@ -41,6 +41,6 @@ parameters:
 # For CI system (do not change)
 hooks:
   before_launch:
-    - !cmd "curl https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/aws-infra/master/managed-ec2-linux-v2.j2 --create-dirs -o templates/remote/managed-ec2-linux-v2.j2"
+    - !cmd "curl https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/managed-ec2-linux-v2.j2 --create-dirs -o templates/remote/managed-ec2-linux-v2.j2"
   after_create:
     - !ec2_notify "{{stack_group_config.aws_account_name}} {{stack_group_config.aws_account_email}}"

--- a/config/prod/dgutman-htan-s3.yaml
+++ b/config/prod/dgutman-htan-s3.yaml
@@ -37,9 +37,7 @@ parameters:
 
 # For CI system (do not change)
 hooks:
-  before_create:
-    - !cmd "curl https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/aws-infra/master/s3-bucket.yaml --create-dirs -o templates/remote/s3-bucket.yaml"
-  before_update:
+  before_launch:
     - !cmd "curl https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/aws-infra/master/s3-bucket.yaml --create-dirs -o templates/remote/s3-bucket.yaml"
   after_create:
     - !s3_notify "{{stack_group_config.aws_account_name}} {{stack_group_config.aws_account_email}}"

--- a/config/prod/dgutman-htan-s3.yaml
+++ b/config/prod/dgutman-htan-s3.yaml
@@ -38,6 +38,6 @@ parameters:
 # For CI system (do not change)
 hooks:
   before_launch:
-    - !cmd "curl https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/aws-infra/master/s3-bucket.yaml --create-dirs -o templates/remote/s3-bucket.yaml"
+    - !cmd "curl https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/s3-bucket.yaml --create-dirs -o templates/remote/s3-bucket.yaml"
   after_create:
     - !s3_notify "{{stack_group_config.aws_account_name}} {{stack_group_config.aws_account_email}}"

--- a/config/prod/dwebster-sandbox-host.yaml
+++ b/config/prod/dwebster-sandbox-host.yaml
@@ -40,9 +40,7 @@ parameters:
 
 # For CI system (do not change)
 hooks:
-  before_create:
-    - !cmd "curl https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/aws-infra/master/managed-ec2-linux-v1.j2 --create-dirs -o templates/remote/managed-ec2-linux-v1.j2"
-  before_update:
+  before_launch:
     - !cmd "curl https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/aws-infra/master/managed-ec2-linux-v1.j2 --create-dirs -o templates/remote/managed-ec2-linux-v1.j2"
   after_create:
     - !ec2_notify "{{stack_group_config.aws_account_name}} {{stack_group_config.aws_account_email}}"

--- a/config/prod/dwebster-sandbox-host.yaml
+++ b/config/prod/dwebster-sandbox-host.yaml
@@ -41,6 +41,6 @@ parameters:
 # For CI system (do not change)
 hooks:
   before_launch:
-    - !cmd "curl https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/aws-infra/master/managed-ec2-linux-v1.j2 --create-dirs -o templates/remote/managed-ec2-linux-v1.j2"
+    - !cmd "curl https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/managed-ec2-linux-v1.j2 --create-dirs -o templates/remote/managed-ec2-linux-v1.j2"
   after_create:
     - !ec2_notify "{{stack_group_config.aws_account_name}} {{stack_group_config.aws_account_email}}"

--- a/config/prod/ecmonsen-emorypipeline-lambda.yaml
+++ b/config/prod/ecmonsen-emorypipeline-lambda.yaml
@@ -11,7 +11,7 @@ parameters:
   Project: amp-ad
   OwnerEmail: eva.monsen@sagebase.org
 hooks:
-  before_create:
+  before_launch:
     # Note: After Sep 30, 2020 only "virtual-hosted" bucket URLs (beginning with https://<bucketname>.s3.amazonaws.com)
     # are supported. See https://aws.amazon.com/blogs/aws/amazon-s3-path-deprecation-plan-the-rest-of-the-story/
 
@@ -19,6 +19,4 @@ hooks:
     #
     # Note the "master" branch always contains the latest successful build. When deploying to production the path
     # should be changed to use "vX.X.X" to deploy from tag vX.X.X
-    - !cmd curl https://ecmonsen-emorypipeline-ci-lambdaartifactsbucket-jnlt9zs4haa7.s3.amazonaws.com/lambda-uploader/master/ecmonsen-emorypipeline-lambda.yaml --create-dirs -o templates/remote/ecmonsen-emorypipeline-lambda.yaml
-  before_update:
     - !cmd curl https://ecmonsen-emorypipeline-ci-lambdaartifactsbucket-jnlt9zs4haa7.s3.amazonaws.com/lambda-uploader/master/ecmonsen-emorypipeline-lambda.yaml --create-dirs -o templates/remote/ecmonsen-emorypipeline-lambda.yaml

--- a/config/prod/jb-new-instance-1.yaml
+++ b/config/prod/jb-new-instance-1.yaml
@@ -39,6 +39,6 @@ parameters:
 # For CI system (do not change)
 hooks:
   before_launch:
-    - !cmd "curl https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/aws-infra/master/managed-ec2-v7.yaml --create-dirs -o templates/remote/managed-ec2.yaml"
+    - !cmd "curl https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/managed-ec2-v7.yaml --create-dirs -o templates/remote/managed-ec2.yaml"
   after_create:
     - !ec2_notify "{{stack_group_config.aws_account_name}} {{stack_group_config.aws_account_email}}"

--- a/config/prod/jb-new-instance-1.yaml
+++ b/config/prod/jb-new-instance-1.yaml
@@ -38,9 +38,7 @@ parameters:
   JcSystemsGroupId: !ssm /infra/JcSystemsGroupId
 # For CI system (do not change)
 hooks:
-  before_create:
-    - !cmd "curl https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/aws-infra/master/managed-ec2-v7.yaml --create-dirs -o templates/remote/managed-ec2.yaml"
-  before_update:
+  before_launch:
     - !cmd "curl https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/aws-infra/master/managed-ec2-v7.yaml --create-dirs -o templates/remote/managed-ec2.yaml"
   after_create:
     - !ec2_notify "{{stack_group_config.aws_account_name}} {{stack_group_config.aws_account_email}}"

--- a/config/prod/jb-nf-vcf-processing.yaml
+++ b/config/prod/jb-nf-vcf-processing.yaml
@@ -41,9 +41,7 @@ parameters:
 
 # For CI system (do not change)
 hooks:
-  before_create:
-    - !cmd "curl https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/aws-infra/master/managed-ec2-v9.j2 --create-dirs -o templates/remote/managed-ec2-v9.j2"
-  before_update:
+  before_launch:
     - !cmd "curl https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/aws-infra/master/managed-ec2-v9.j2 --create-dirs -o templates/remote/managed-ec2-v9.j2"
   after_create:
     - !ec2_notify "{{stack_group_config.aws_account_name}} {{stack_group_config.aws_account_email}}"

--- a/config/prod/jb-nf-vcf-processing.yaml
+++ b/config/prod/jb-nf-vcf-processing.yaml
@@ -42,6 +42,6 @@ parameters:
 # For CI system (do not change)
 hooks:
   before_launch:
-    - !cmd "curl https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/aws-infra/master/managed-ec2-v9.j2 --create-dirs -o templates/remote/managed-ec2-v9.j2"
+    - !cmd "curl https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/managed-ec2-v9.j2 --create-dirs -o templates/remote/managed-ec2-v9.j2"
   after_create:
     - !ec2_notify "{{stack_group_config.aws_account_name}} {{stack_group_config.aws_account_email}}"

--- a/config/prod/kd-awslinux-ec2.yaml
+++ b/config/prod/kd-awslinux-ec2.yaml
@@ -40,6 +40,6 @@ parameters:
 # For CI system (do not change)
 hooks:
   before_launch:
-    - !cmd "curl https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/aws-infra/master/managed-ec2-v10.j2 --create-dirs -o templates/remote/managed-ec2-v10.j2"
+    - !cmd "curl https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/managed-ec2-v10.j2 --create-dirs -o templates/remote/managed-ec2-v10.j2"
   after_create:
     - !ec2_notify "{{stack_group_config.aws_account_name}} {{stack_group_config.aws_account_email}}"

--- a/config/prod/kd-awslinux-ec2.yaml
+++ b/config/prod/kd-awslinux-ec2.yaml
@@ -39,9 +39,7 @@ parameters:
 
 # For CI system (do not change)
 hooks:
-  before_create:
-    - !cmd "curl https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/aws-infra/master/managed-ec2-v10.j2 --create-dirs -o templates/remote/managed-ec2-v10.j2"
-  before_update:
+  before_launch:
     - !cmd "curl https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/aws-infra/master/managed-ec2-v10.j2 --create-dirs -o templates/remote/managed-ec2-v10.j2"
   after_create:
     - !ec2_notify "{{stack_group_config.aws_account_name}} {{stack_group_config.aws_account_email}}"

--- a/config/prod/kd-ubuntu-ec2.yaml
+++ b/config/prod/kd-ubuntu-ec2.yaml
@@ -42,6 +42,6 @@ parameters:
 # For CI system (do not change)
 hooks:
   before_launch:
-    - !cmd "curl https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/aws-infra/master/managed-ec2-ubuntu-v2.j2 --create-dirs -o templates/remote/managed-ec2-ubuntu-v2.j2"
+    - !cmd "curl https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/managed-ec2-ubuntu-v2.j2 --create-dirs -o templates/remote/managed-ec2-ubuntu-v2.j2"
   after_create:
     - !ec2_notify "{{stack_group_config.aws_account_name}} {{stack_group_config.aws_account_email}}"

--- a/config/prod/kd-ubuntu-ec2.yaml
+++ b/config/prod/kd-ubuntu-ec2.yaml
@@ -41,9 +41,7 @@ parameters:
 
 # For CI system (do not change)
 hooks:
-  before_create:
-    - !cmd "curl https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/aws-infra/master/managed-ec2-ubuntu-v2.j2 --create-dirs -o templates/remote/managed-ec2-ubuntu-v2.j2"
-  before_update:
+  before_launch:
     - !cmd "curl https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/aws-infra/master/managed-ec2-ubuntu-v2.j2 --create-dirs -o templates/remote/managed-ec2-ubuntu-v2.j2"
   after_create:
     - !ec2_notify "{{stack_group_config.aws_account_name}} {{stack_group_config.aws_account_email}}"

--- a/config/prod/kd-win-ec2.yaml
+++ b/config/prod/kd-win-ec2.yaml
@@ -40,6 +40,6 @@ parameters:
 # For CI system (do not change)
 hooks:
   before_launch:
-    - !cmd "curl https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/aws-infra/master/managed-ec2-win-v4.j2 --create-dirs -o templates/remote/managed-ec2-win-v4.j2"
+    - !cmd "curl https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/managed-ec2-win-v4.j2 --create-dirs -o templates/remote/managed-ec2-win-v4.j2"
   after_create:
     - !ec2_notify "{{stack_group_config.aws_account_name}} {{stack_group_config.aws_account_email}}"

--- a/config/prod/kd-win-ec2.yaml
+++ b/config/prod/kd-win-ec2.yaml
@@ -39,9 +39,7 @@ parameters:
 
 # For CI system (do not change)
 hooks:
-  before_create:
-    - !cmd "curl https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/aws-infra/master/managed-ec2-win-v4.j2 --create-dirs -o templates/remote/managed-ec2-win-v4.j2"
-  before_update:
+  before_launch:
     - !cmd "curl https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/aws-infra/master/managed-ec2-win-v4.j2 --create-dirs -o templates/remote/managed-ec2-win-v4.j2"
   after_create:
     - !ec2_notify "{{stack_group_config.aws_account_name}} {{stack_group_config.aws_account_email}}"

--- a/config/prod/mmason-beefier-bioc.yaml
+++ b/config/prod/mmason-beefier-bioc.yaml
@@ -43,6 +43,6 @@ parameters:
 # For CI system (do not change)
 hooks:
   before_launch:
-    - !cmd "curl https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/aws-infra/master/managed-ec2-ubuntu-v3.j2 --create-dirs -o templates/remote/managed-ec2-ubuntu-v3.j2"
+    - !cmd "curl https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/managed-ec2-ubuntu-v3.j2 --create-dirs -o templates/remote/managed-ec2-ubuntu-v3.j2"
   after_create:
     - !ec2_notify "{{stack_group_config.aws_account_name}} {{stack_group_config.aws_account_email}}"

--- a/config/prod/mmason-beefier-bioc.yaml
+++ b/config/prod/mmason-beefier-bioc.yaml
@@ -42,9 +42,7 @@ parameters:
 
 # For CI system (do not change)
 hooks:
-  before_create:
-    - !cmd "curl https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/aws-infra/master/managed-ec2-ubuntu-v3.j2 --create-dirs -o templates/remote/managed-ec2-ubuntu-v3.j2"
-  before_update:
+  before_launch:
     - !cmd "curl https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/aws-infra/master/managed-ec2-ubuntu-v3.j2 --create-dirs -o templates/remote/managed-ec2-ubuntu-v3.j2"
   after_create:
     - !ec2_notify "{{stack_group_config.aws_account_name}} {{stack_group_config.aws_account_email}}"

--- a/config/prod/mmason-general-bioc.yaml
+++ b/config/prod/mmason-general-bioc.yaml
@@ -42,6 +42,6 @@ parameters:
 # For CI system (do not change)
 hooks:
   before_launch:
-    - !cmd "curl https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/aws-infra/master/managed-ec2-ubuntu-v3.j2 --create-dirs -o templates/remote/managed-ec2-ubuntu-v3.j2"
+    - !cmd "curl https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/managed-ec2-ubuntu-v3.j2 --create-dirs -o templates/remote/managed-ec2-ubuntu-v3.j2"
   after_create:
     - !ec2_notify "{{stack_group_config.aws_account_name}} {{stack_group_config.aws_account_email}}"

--- a/config/prod/mmason-general-bioc.yaml
+++ b/config/prod/mmason-general-bioc.yaml
@@ -41,9 +41,7 @@ parameters:
 
 # For CI system (do not change)
 hooks:
-  before_create:
-    - !cmd "curl https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/aws-infra/master/managed-ec2-ubuntu-v3.j2 --create-dirs -o templates/remote/managed-ec2-ubuntu-v3.j2"
-  before_update:
+  before_launch:
     - !cmd "curl https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/aws-infra/master/managed-ec2-ubuntu-v3.j2 --create-dirs -o templates/remote/managed-ec2-ubuntu-v3.j2"
   after_create:
     - !ec2_notify "{{stack_group_config.aws_account_name}} {{stack_group_config.aws_account_email}}"

--- a/config/prod/tom-ncats.yaml
+++ b/config/prod/tom-ncats.yaml
@@ -40,9 +40,7 @@ parameters:
 
 # For CI system (do not change)
 hooks:
-  before_create:
-    - !cmd "curl https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/aws-infra/master/managed-ec2-linux-v1.j2 --create-dirs -o templates/remote/managed-ec2-linux-v1.j2"
-  before_update:
+  before_launch:
     - !cmd "curl https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/aws-infra/master/managed-ec2-linux-v1.j2 --create-dirs -o templates/remote/managed-ec2-linux-v1.j2"
   after_create:
     - !ec2_notify "{{stack_group_config.aws_account_name}} {{stack_group_config.aws_account_email}}"

--- a/config/prod/tom-ncats.yaml
+++ b/config/prod/tom-ncats.yaml
@@ -41,6 +41,6 @@ parameters:
 # For CI system (do not change)
 hooks:
   before_launch:
-    - !cmd "curl https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/aws-infra/master/managed-ec2-linux-v1.j2 --create-dirs -o templates/remote/managed-ec2-linux-v1.j2"
+    - !cmd "curl https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/managed-ec2-linux-v1.j2 --create-dirs -o templates/remote/managed-ec2-linux-v1.j2"
   after_create:
     - !ec2_notify "{{stack_group_config.aws_account_name}} {{stack_group_config.aws_account_email}}"

--- a/config/prod/tom-nextflow.yaml
+++ b/config/prod/tom-nextflow.yaml
@@ -41,6 +41,6 @@ parameters:
 # For CI system (do not change)
 hooks:
   before_launch:
-    - !cmd "curl https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/aws-infra/master/managed-ec2-linux-v2.j2 --create-dirs -o templates/remote/managed-ec2-linux-v2.j2"
+    - !cmd "curl https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/managed-ec2-linux-v2.j2 --create-dirs -o templates/remote/managed-ec2-linux-v2.j2"
   after_create:
     - !ec2_notify "{{stack_group_config.aws_account_name}} {{stack_group_config.aws_account_email}}"

--- a/config/prod/tom-rstudio.yaml
+++ b/config/prod/tom-rstudio.yaml
@@ -42,6 +42,6 @@ parameters:
 # For CI system (do not change)
 hooks:
   before_launch:
-    - !cmd "curl https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/aws-infra/master/managed-ec2-linux-v2.j2 --create-dirs -o templates/remote/managed-ec2-linux-v2.j2"
+    - !cmd "curl https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/managed-ec2-linux-v2.j2 --create-dirs -o templates/remote/managed-ec2-linux-v2.j2"
   after_create:
     - !ec2_notify "{{stack_group_config.aws_account_name}} {{stack_group_config.aws_account_email}}"

--- a/config/prod/ubuntu-rstudio-ami.yaml
+++ b/config/prod/ubuntu-rstudio-ami.yaml
@@ -42,6 +42,6 @@ parameters:
 # For CI system (do not change)
 hooks:
   before_launch:
-    - !cmd "curl https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/aws-infra/master/managed-ec2-ubuntu-v2.j2 --create-dirs -o templates/remote/managed-ec2-ubuntu-v2.j2"
+    - !cmd "curl https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/managed-ec2-ubuntu-v2.j2 --create-dirs -o templates/remote/managed-ec2-ubuntu-v2.j2"
   after_create:
     - !ec2_notify "{{stack_group_config.aws_account_name}} {{stack_group_config.aws_account_email}}"

--- a/config/prod/ubuntu-rstudio-ami.yaml
+++ b/config/prod/ubuntu-rstudio-ami.yaml
@@ -41,9 +41,7 @@ parameters:
 
 # For CI system (do not change)
 hooks:
-  before_create:
-    - !cmd "curl https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/aws-infra/master/managed-ec2-ubuntu-v2.j2 --create-dirs -o templates/remote/managed-ec2-ubuntu-v2.j2"
-  before_update:
+  before_launch:
     - !cmd "curl https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/aws-infra/master/managed-ec2-ubuntu-v2.j2 --create-dirs -o templates/remote/managed-ec2-ubuntu-v2.j2"
   after_create:
     - !ec2_notify "{{stack_group_config.aws_account_name}} {{stack_group_config.aws_account_email}}"

--- a/config/prod/verena-beat-aml-final.yaml
+++ b/config/prod/verena-beat-aml-final.yaml
@@ -41,6 +41,6 @@ parameters:
 # For CI system (do not change)
 hooks:
   before_launch:
-    - !cmd "curl https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/aws-infra/master/managed-ec2-linux-v1.j2 --create-dirs -o templates/remote/managed-ec2-linux-v1.j2"
+    - !cmd "curl https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/managed-ec2-linux-v1.j2 --create-dirs -o templates/remote/managed-ec2-linux-v1.j2"
   after_create:
     - !ec2_notify "{{stack_group_config.aws_account_name}} {{stack_group_config.aws_account_email}}"

--- a/config/prod/verena-beat-aml2.yaml
+++ b/config/prod/verena-beat-aml2.yaml
@@ -41,6 +41,6 @@ parameters:
 # For CI system (do not change)
 hooks:
   before_launch:
-    - !cmd "curl https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/aws-infra/master/managed-ec2-linux-v1.j2 --create-dirs -o templates/remote/managed-ec2-linux-v1.j2"
+    - !cmd "curl https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/managed-ec2-linux-v1.j2 --create-dirs -o templates/remote/managed-ec2-linux-v1.j2"
   after_create:
     - !ec2_notify "{{stack_group_config.aws_account_name}} {{stack_group_config.aws_account_email}}"

--- a/config/prod/verena-instance.yaml
+++ b/config/prod/verena-instance.yaml
@@ -40,9 +40,7 @@ parameters:
 
 # For CI system (do not change)
 hooks:
-  before_create:
-    - !cmd "curl https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/aws-infra/master/managed-ec2-linux-v1.j2 --create-dirs -o templates/remote/managed-ec2-linux-v1.j2"
-  before_update:
+  before_launch:
     - !cmd "curl https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/aws-infra/master/managed-ec2-linux-v1.j2 --create-dirs -o templates/remote/managed-ec2-linux-v1.j2"
   after_create:
     - !ec2_notify "{{stack_group_config.aws_account_name}} {{stack_group_config.aws_account_email}}"

--- a/config/prod/verena-instance.yaml
+++ b/config/prod/verena-instance.yaml
@@ -41,6 +41,6 @@ parameters:
 # For CI system (do not change)
 hooks:
   before_launch:
-    - !cmd "curl https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/aws-infra/master/managed-ec2-linux-v1.j2 --create-dirs -o templates/remote/managed-ec2-linux-v1.j2"
+    - !cmd "curl https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/managed-ec2-linux-v1.j2 --create-dirs -o templates/remote/managed-ec2-linux-v1.j2"
   after_create:
     - !ec2_notify "{{stack_group_config.aws_account_name}} {{stack_group_config.aws_account_email}}"

--- a/config/prod/xdoan-clarisse-htan-s3.yaml
+++ b/config/prod/xdoan-clarisse-htan-s3.yaml
@@ -37,9 +37,7 @@ parameters:
 
 # For CI system (do not change)
 hooks:
-  before_create:
-    - !cmd "curl https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/aws-infra/master/s3-bucket.yaml --create-dirs -o templates/remote/s3-bucket.yaml"
-  before_update:
+  before_launch:
     - !cmd "curl https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/aws-infra/master/s3-bucket.yaml --create-dirs -o templates/remote/s3-bucket.yaml"
   after_create:
     - !s3_notify "{{stack_group_config.aws_account_name}} {{stack_group_config.aws_account_email}}"

--- a/config/prod/xdoan-clarisse-htan-s3.yaml
+++ b/config/prod/xdoan-clarisse-htan-s3.yaml
@@ -38,6 +38,6 @@ parameters:
 # For CI system (do not change)
 hooks:
   before_launch:
-    - !cmd "curl https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/aws-infra/master/s3-bucket.yaml --create-dirs -o templates/remote/s3-bucket.yaml"
+    - !cmd "curl https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/s3-bucket.yaml --create-dirs -o templates/remote/s3-bucket.yaml"
   after_create:
     - !s3_notify "{{stack_group_config.aws_account_name}} {{stack_group_config.aws_account_email}}"

--- a/config/prod/xdoan-htan-ec2.yaml
+++ b/config/prod/xdoan-htan-ec2.yaml
@@ -41,6 +41,6 @@ parameters:
 # For CI system (do not change)
 hooks:
   before_launch:
-    - !cmd "curl https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/aws-infra/master/managed-ec2-linux-v2.j2 --create-dirs -o templates/remote/managed-ec2-linux-v2.j2"
+    - !cmd "curl https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/managed-ec2-linux-v2.j2 --create-dirs -o templates/remote/managed-ec2-linux-v2.j2"
   after_create:
     - !ec2_notify "{{stack_group_config.aws_account_name}} {{stack_group_config.aws_account_email}}"

--- a/config/prod/xdoan-test-s3.yaml
+++ b/config/prod/xdoan-test-s3.yaml
@@ -37,6 +37,6 @@ parameters:
 # For CI system (do not change)
 hooks:
   before_launch:
-    - !cmd "curl https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/aws-infra/master/s3-bucket.yaml --create-dirs -o templates/remote/s3-bucket.yaml"
+    - !cmd "curl https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/s3-bucket.yaml --create-dirs -o templates/remote/s3-bucket.yaml"
   after_create:
     - !s3_notify "{{stack_group_config.aws_account_name}} {{stack_group_config.aws_account_email}}"

--- a/config/prod/xdoan-test-s3.yaml
+++ b/config/prod/xdoan-test-s3.yaml
@@ -36,9 +36,7 @@ parameters:
 
 # For CI system (do not change)
 hooks:
-  before_create:
-    - !cmd "curl https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/aws-infra/master/s3-bucket.yaml --create-dirs -o templates/remote/s3-bucket.yaml"
-  before_update:
+  before_launch:
     - !cmd "curl https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/aws-infra/master/s3-bucket.yaml --create-dirs -o templates/remote/s3-bucket.yaml"
   after_create:
     - !s3_notify "{{stack_group_config.aws_account_name}} {{stack_group_config.aws_account_email}}"

--- a/config/prod/xind-cvat-test.yaml
+++ b/config/prod/xind-cvat-test.yaml
@@ -40,9 +40,7 @@ parameters:
 
 # For CI system (do not change)
 hooks:
-  before_create:
-    - !cmd "curl https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/aws-infra/master/managed-ec2-linux-v1.j2 --create-dirs -o templates/remote/managed-ec2-linux-v1.j2"
-  before_update:
+  before_launch:
     - !cmd "curl https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/aws-infra/master/managed-ec2-linux-v1.j2 --create-dirs -o templates/remote/managed-ec2-linux-v1.j2"
   after_create:
     - !ec2_notify "{{stack_group_config.aws_account_name}} {{stack_group_config.aws_account_email}}"

--- a/config/prod/xind-cvat-test.yaml
+++ b/config/prod/xind-cvat-test.yaml
@@ -41,6 +41,6 @@ parameters:
 # For CI system (do not change)
 hooks:
   before_launch:
-    - !cmd "curl https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/aws-infra/master/managed-ec2-linux-v1.j2 --create-dirs -o templates/remote/managed-ec2-linux-v1.j2"
+    - !cmd "curl https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/managed-ec2-linux-v1.j2 --create-dirs -o templates/remote/managed-ec2-linux-v1.j2"
   after_create:
     - !ec2_notify "{{stack_group_config.aws_account_name}} {{stack_group_config.aws_account_email}}"

--- a/config/prod/xschildw-packertest.yaml
+++ b/config/prod/xschildw-packertest.yaml
@@ -40,9 +40,7 @@ parameters:
 
 # For CI system (do not change)
 hooks:
-  before_create:
-    - !cmd "curl https://{{stack_group_config.admincentral_cf_bucket}}.s3.us-east-1.amazonaws.com/aws-infra/master/managed-ec2-linux-v2.j2 --create-dirs -o templates/remote/managed-ec2-linux-v2.j2"
-  before_update:
+  before_launch:
     - !cmd "curl https://{{stack_group_config.admincentral_cf_bucket}}.s3.us-east-1.amazonaws.com/aws-infra/master/managed-ec2-linux-v2.j2 --create-dirs -o templates/remote/managed-ec2-linux-v2.j2"
   after_create:
     - !ec2_notify "{{stack_group_config.aws_account_name}} {{stack_group_config.aws_account_email}}"

--- a/config/prod/xschildw-rsconnect.yaml
+++ b/config/prod/xschildw-rsconnect.yaml
@@ -40,9 +40,7 @@ parameters:
 
 # For CI system (do not change)
 hooks:
-  before_create:
-    - !cmd "curl https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/aws-infra/master/managed-ec2-linux-v1.j2 --create-dirs -o templates/remote/managed-ec2-linux-v1.j2"
-  before_update:
+  before_launch:
     - !cmd "curl https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/aws-infra/master/managed-ec2-linux-v1.j2 --create-dirs -o templates/remote/managed-ec2-linux-v1.j2"
   after_create:
     - !ec2_notify "{{stack_group_config.aws_account_name}} {{stack_group_config.aws_account_email}}"

--- a/config/prod/xschildw-rsconnect.yaml
+++ b/config/prod/xschildw-rsconnect.yaml
@@ -41,6 +41,6 @@ parameters:
 # For CI system (do not change)
 hooks:
   before_launch:
-    - !cmd "curl https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/aws-infra/master/managed-ec2-linux-v1.j2 --create-dirs -o templates/remote/managed-ec2-linux-v1.j2"
+    - !cmd "curl https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/managed-ec2-linux-v1.j2 --create-dirs -o templates/remote/managed-ec2-linux-v1.j2"
   after_create:
     - !ec2_notify "{{stack_group_config.aws_account_name}} {{stack_group_config.aws_account_email}}"

--- a/config/prod/xschildw-shinyproxy.yaml
+++ b/config/prod/xschildw-shinyproxy.yaml
@@ -40,9 +40,7 @@ parameters:
 
 # For CI system (do not change)
 hooks:
-  before_create:
-    - !cmd "curl https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/aws-infra/master/managed-ec2-linux-v1.j2 --create-dirs -o templates/remote/managed-ec2-linux-v1.j2"
-  before_update:
+  before_launch:
     - !cmd "curl https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/aws-infra/master/managed-ec2-linux-v1.j2 --create-dirs -o templates/remote/managed-ec2-linux-v1.j2"
   after_create:
     - !ec2_notify "{{stack_group_config.aws_account_name}} {{stack_group_config.aws_account_email}}"

--- a/config/prod/xschildw-shinyproxy.yaml
+++ b/config/prod/xschildw-shinyproxy.yaml
@@ -41,6 +41,6 @@ parameters:
 # For CI system (do not change)
 hooks:
   before_launch:
-    - !cmd "curl https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/aws-infra/master/managed-ec2-linux-v1.j2 --create-dirs -o templates/remote/managed-ec2-linux-v1.j2"
+    - !cmd "curl https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/managed-ec2-linux-v1.j2 --create-dirs -o templates/remote/managed-ec2-linux-v1.j2"
   after_create:
     - !ec2_notify "{{stack_group_config.aws_account_name}} {{stack_group_config.aws_account_email}}"

--- a/config/prod/xschildw-wininst.yaml
+++ b/config/prod/xschildw-wininst.yaml
@@ -38,9 +38,7 @@ parameters:
   JcSystemsGroupId: !ssm /infra/JcSystemsGroupId
 # For CI system (do not change)
 hooks:
-  before_create:
-    - !cmd "curl https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/aws-infra/master/managed-ec2-win-v1.yaml --create-dirs -o templates/remote/managed-ec2-win.yaml"
-  before_update:
+  before_launch:
     - !cmd "curl https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/aws-infra/master/managed-ec2-win-v1.yaml --create-dirs -o templates/remote/managed-ec2-win.yaml"
   after_create:
     - !ec2_notify "{{stack_group_config.aws_account_name}} {{stack_group_config.aws_account_email}}"

--- a/config/prod/xschildw-wininst.yaml
+++ b/config/prod/xschildw-wininst.yaml
@@ -39,6 +39,6 @@ parameters:
 # For CI system (do not change)
 hooks:
   before_launch:
-    - !cmd "curl https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/aws-infra/master/managed-ec2-win-v1.yaml --create-dirs -o templates/remote/managed-ec2-win.yaml"
+    - !cmd "curl https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/managed-ec2-win-v1.yaml --create-dirs -o templates/remote/managed-ec2-win.yaml"
   after_create:
     - !ec2_notify "{{stack_group_config.aws_account_name}} {{stack_group_config.aws_account_email}}"

--- a/config/prod/zaroirc.yaml
+++ b/config/prod/zaroirc.yaml
@@ -41,9 +41,7 @@ sceptre_user_data:
 
 # For CI system (do not change)
 hooks:
-  before_create:
-    - !cmd "curl https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/aws-infra/master/managed-ec2-ubuntu-v2.j2 --create-dirs -o templates/remote/managed-ec2-ubuntu-v2.j2"
-  before_update:
+  before_launch:
     - !cmd "curl https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/aws-infra/master/managed-ec2-ubuntu-v2.j2 --create-dirs -o templates/remote/managed-ec2-ubuntu-v2.j2"
   after_create:
     - !ec2_notify "{{stack_group_config.aws_account_name}} {{stack_group_config.aws_account_email}}"

--- a/config/prod/zaroirc.yaml
+++ b/config/prod/zaroirc.yaml
@@ -42,6 +42,6 @@ sceptre_user_data:
 # For CI system (do not change)
 hooks:
   before_launch:
-    - !cmd "curl https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/aws-infra/master/managed-ec2-ubuntu-v2.j2 --create-dirs -o templates/remote/managed-ec2-ubuntu-v2.j2"
+    - !cmd "curl https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/managed-ec2-ubuntu-v2.j2 --create-dirs -o templates/remote/managed-ec2-ubuntu-v2.j2"
   after_create:
     - !ec2_notify "{{stack_group_config.aws_account_name}} {{stack_group_config.aws_account_email}}"

--- a/templates/managed-ec2-v6.yaml
+++ b/templates/managed-ec2-v6.yaml
@@ -547,7 +547,7 @@ Resources:
     Condition: EnableEc2Backup
     Properties:
       # template uploaded from Sage-Bionetworks/aws-infra repo
-      TemplateURL: 'https://s3.amazonaws.com/bootstrap-awss3cloudformationbucket-19qromfd235z9/aws-infra/master/ec2-backup.yaml'
+      TemplateURL: 'https://bootstrap-awss3cloudformationbucket-19qromfd235z9.s3.amazonaws.com/aws-infra/master/ec2-backup.yaml'
       Parameters:
         StackName: !Ref AWS::StackName
         SnapshotCount: !Ref SnapshotCount


### PR DESCRIPTION
Change S3 URL format to meet the new standard (i.e. bucket name as subdomain, instead of start of path).