### PR TITLE
Create service account for Nextflow S3 access

### DIFF
--- a/config/prod/bgrande-nextflow-iam.yaml
+++ b/config/prod/bgrande-nextflow-iam.yaml
@@ -1,0 +1,12 @@
+# Provision a service account for AWS API access keys
+template_path: "remote/service-account.yaml"
+stack_name: "bgrande-nextflow-iam-service-account"
+parameters:
+  Department: "CompOnc"
+  Project: "imCORE"
+  OwnerEmail: "bruno.grande@sagebase.org"
+  ManagedPolicyArns: ["arn:aws:iam::aws:policy/AmazonS3FullAccess"]
+
+hooks:
+  before_launch:
+    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/IAM/service-account.yaml -N -P templates/remote"

--- a/config/prod/bgrande-nextflow-service-account.yaml
+++ b/config/prod/bgrande-nextflow-service-account.yaml
@@ -1,14 +1,13 @@
 # Provision a service account for AWS API access keys
 template_path: "remote/service-account.yaml"
 stack_name: "bgrande-nextflow-service-account"
-parameters:
+stack_tags:
   Department: "CompOnc"
   Project: "imCORE"
   OwnerEmail: "bruno.grande@sagebase.org"
+parameters:
   ManagedPolicyArns: ["arn:aws:iam::aws:policy/AmazonS3FullAccess"]
 
 hooks:
   before_launch:
     - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/IAM/service-account.yaml -N -P templates/remote"
-  after_create:
-    - !s3_notify "{{stack_group_config.aws_account_name}} {{stack_group_config.aws_account_email}}"

--- a/config/prod/bgrande-nextflow-service-account.yaml
+++ b/config/prod/bgrande-nextflow-service-account.yaml
@@ -10,3 +10,5 @@ parameters:
 hooks:
   before_launch:
     - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/IAM/service-account.yaml -N -P templates/remote"
+  after_create:
+    - !s3_notify "{{stack_group_config.aws_account_name}} {{stack_group_config.aws_account_email}}"

--- a/config/prod/bgrande-nextflow-service-account.yaml
+++ b/config/prod/bgrande-nextflow-service-account.yaml
@@ -1,6 +1,6 @@
 # Provision a service account for AWS API access keys
 template_path: "remote/service-account.yaml"
-stack_name: "bgrande-nextflow-iam-service-account"
+stack_name: "bgrande-nextflow-service-account"
 parameters:
   Department: "CompOnc"
   Project: "imCORE"


### PR DESCRIPTION
This service account will be used by Nextflow to store intermediate files in S3 while running a data processing workflow. I can't use my `sandbox-developer` role because the credentials expire in 8 hours whereas workflows can run for days. I'm going to test this setup using non-PHI data. If it works, I'll set up an equivalent service account in `scicomp`. 

This PR isn't based on a template, but it's inspired by the [stack](https://github.com/Sage-Bionetworks-IT/organizations-infra/blob/master/org-formation/600-access/_tasks.yaml#L77-L89) I deployed for the Nextflow provisioner CI. I'm using `wget` as per the recommendation made when I authored this [stack](https://github.com/Sage-Bionetworks-Workflows/aws-workflows-nextflow-infra/blob/prod/config/prod/s3-cfn-templates.yaml#L1-L9). 

----

### PR Checklist

- [x] Describe your resource request in your commit message
  Example: "Request a memory optimized EC2 to run analysis on amp-ad data"
- [x] Use the latest version of an example template
  https://github.com/Sage-Bionetworks/sandbox-provisioner/pulls?utf8=%E2%9C%93&q=is%3Aopen+%22Example+PR%3A%22
- [x] Setup pre-commit and run the validators (info in README.md)
  To validate files run: `pre-commit run --all-files`
