### PR TITLE
Create short-term production DSA server

### DIFF
--- a/config/prod/dgutman-dsa-server-preprod-ec2.yaml
+++ b/config/prod/dgutman-dsa-server-preprod-ec2.yaml
@@ -1,6 +1,6 @@
 # Provision an EC2 instance
 template_path: "remote/managed-ec2-linux-v2.j2"
-stack_name: "dgutman-dsa-server-prod-ec2"
+stack_name: "dgutman-dsa-server-preprod-ec2"
 sceptre_user_data:
   Distro: "ubuntu"     # (valid values: aws, ubuntu) AMIId must match distro
   # (Optional) Expose ports to incoming traffic (default is no open ports) (valid range: 1-65535)
@@ -17,7 +17,7 @@ parameters:
   VpcName: "sandcastlevpc"
   KeyName: "EmoryHealthcare-dgutman"
   # AMIId: "ami-0810a318c4b1243c5"      # https://github.com/Sage-Bionetworks-IT/packer-base-amazonlinux2/releases/tag/v1.0.2
-  AMIId: "ami-0447d7789ebc37ae3"    # https://github.com/Sage-Bionetworks-IT/packer-base-ubuntu-bionic/releases/tag/v1.0.7
+  AMIId: "ami-0b7906ab614596e7e"    # https://github.com/Sage-Bionetworks-IT/packer-base-ubuntu-bionic/releases/tag/v1.0.9
 
   # Settings have default values but can be overriden. Set the below
   # parameters *only* if you want to override the defaults.

--- a/config/prod/dgutman-dsa-server-prod-ec2.yaml
+++ b/config/prod/dgutman-dsa-server-prod-ec2.yaml
@@ -1,0 +1,46 @@
+# Provision an EC2 instance
+template_path: "remote/managed-ec2-linux-v2.j2"
+stack_name: "dgutman-dsa-server-prod-ec2"
+sceptre_user_data:
+  Distro: "ubuntu"     # (valid values: aws, ubuntu) AMIId must match distro
+  # (Optional) Expose ports to incoming traffic (default is no open ports) (valid range: 1-65535)
+  OpenPorts: ["80","443", "22"]
+parameters:
+  # The Sage deparment (Platform, CompOnc, SysBio, Governance, etc..)
+  Department: "CompOnc"
+  # The Sage project (Infrastructure, amp-ad, ntap, dream, etc..)
+  Project: "HTAN"
+  # The resource owner
+  OwnerEmail: "bruno.grande@sagebase.org"
+
+  # Default account settings, leave alone unless you plan to override
+  VpcName: "sandcastlevpc"
+  KeyName: "EmoryHealthcare-dgutman"
+  # AMIId: "ami-0810a318c4b1243c5"      # https://github.com/Sage-Bionetworks-IT/packer-base-amazonlinux2/releases/tag/v1.0.2
+  AMIId: "ami-0447d7789ebc37ae3"    # https://github.com/Sage-Bionetworks-IT/packer-base-ubuntu-bionic/releases/tag/v1.0.7
+
+  # Settings have default values but can be overriden. Set the below
+  # parameters *only* if you want to override the defaults.
+
+  # (Optional) EC2 instance type, default is "t3.micro" (other available types https://aws.amazon.com/ec2/pricing/on-demand/)
+  InstanceType: "i3en.2xlarge"
+  # (Optional) EC2 boot volume size in GB, default is 8GB, Max is 1000GB
+  VolumeSize: "1000"
+  # (Optional) Run EC2 in a subnet (default: PrivateSubnet) (valid values: PrivateSubnet or PublicSubnet)
+  VpcSubnet: "PublicSubnet"
+  # (Optional) Set true to enable daily backups (default: false)
+  # BackupEc2: "true"
+  # (Optional) Number of daily backups to keep (default: 7) (valid range: 1-180)
+  # SnapshotCount: "14"
+
+  # Integration with our jumpcloud directory service (do not change)
+  JcConnectKey: !ssm "/infra/JcConnectKey"
+  JcServiceApiKey: !ssm "/infra/JcServiceApiKey"
+  JcSystemsGroupId: !ssm "/infra/JcSystemsGroupId"
+
+# For CI system (do not change)
+hooks:
+  before_launch:
+    - !cmd "curl https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/managed-ec2-linux-v2.j2 --create-dirs -o templates/remote/managed-ec2-linux-v2.j2"
+  after_create:
+    - !ec2_notify "{{stack_group_config.aws_account_name}} {{stack_group_config.aws_account_email}}"


### PR DESCRIPTION
The `dgutman-dsa-server-prod-ec2.yaml` stack being added here is a duplicate of `dgutman-htan-new2-ec2.yaml`. This new EC2 instance will be used as a short-term production server until we deploy something long-term (see IT-1214). The original stack will remain for now as a development server. 

For context, DSA stands for the Digital Slide Archive, which is an imaging file viewer being hosted for the HTAN project. 

----

PR Checklist:
- [x] Describe your resource request in your commit message
- [x] (Not applicable) Use the latest version of an example template 
- [x] Setup pre-commit and run the validators (info in README.md)
