### PR TITLE
Fix DSA resource deployment

### DIFF
--- a/config/prod/dgutman-htan-new2-ec2.yaml
+++ b/config/prod/dgutman-htan-new2-ec2.yaml
@@ -15,7 +15,7 @@ parameters:
 
   # Default account settings, leave alone unless you plan to override
   VpcName: "sandcastlevpc"
-  # KeyName: "EmoryHealthcare-dgutman"
+  KeyName: "sandbox"
   # AMIId: "ami-0810a318c4b1243c5"      # https://github.com/Sage-Bionetworks-IT/packer-base-amazonlinux2/releases/tag/v1.0.2
   AMIId: "ami-0447d7789ebc37ae3"    # https://github.com/Sage-Bionetworks-IT/packer-base-ubuntu-bionic/releases/tag/v1.0.7
 


### PR DESCRIPTION
PR #389 commented out `KeyName` parameter which caused
a deployment failure because that a required parameter
in the referenced managed-ec2-linux-v2.j2 template.

The way to correctly fix remove access to an EC2 keypair
is to switch to another one that the user does not have
access to.