### PR TITLE
Use sceptre template handlers

### DIFF
--- a/config/prod/JKG-s3.yaml
+++ b/config/prod/JKG-s3.yaml
@@ -1,5 +1,7 @@
 # Provision a Synapse External Bucket (http://docs.synapse.org/articles/custom_storage_location.html)
-template_path: "remote/s3-bucket.yaml"
+template:
+  type: "http"
+  url: "https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.2.7/s3-bucket.yaml"
 stack_name: "JKG-s3"
 parameters:
   # The Sage deparment (Platform, CompOnc, SysBio, Governance, etc..)
@@ -16,9 +18,3 @@ parameters:
   GrantAccess:
     - 'arn:aws:iam::325565585839:root'   # Required ARN for a synapse bucket
     - 'arn:aws:sts::563295687221:assumed-role/AWSReservedSSO_Developer_baa6fed639faf5e7/jake.gockley@sagebase.org'
-
-hooks:
-  before_launch:
-    - !cmd "curl https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.2.7/s3-bucket.yaml --create-dirs -o templates/remote/s3-bucket.yaml"
-  after_create:
-    - !s3_notify "{{stack_group_config.aws_account_name}} {{stack_group_config.aws_account_email}}"

--- a/config/prod/bgrande-nextflow-service-account.yaml
+++ b/config/prod/bgrande-nextflow-service-account.yaml
@@ -1,5 +1,7 @@
 # Provision a service account for AWS API access keys
-template_path: "remote/service-account.yaml"
+template:
+  type: "http"
+  url: "https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.2.7/IAM/service-account.yaml"
 stack_name: "bgrande-nextflow-service-account"
 stack_tags:
   Department: "CompOnc"
@@ -7,7 +9,3 @@ stack_tags:
   OwnerEmail: "bruno.grande@sagebase.org"
 parameters:
   ManagedPolicyArns: ["arn:aws:iam::aws:policy/AmazonS3FullAccess"]
-
-hooks:
-  before_launch:
-    - !cmd "wget https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.2.7/IAM/service-account.yaml -O templates/remote/service-account.yaml"

--- a/config/prod/dgutman-htan-new2-ec2.yaml
+++ b/config/prod/dgutman-htan-new2-ec2.yaml
@@ -1,5 +1,7 @@
 # Provision an EC2 instance
-template_path: "remote/managed-ec2-linux-v2.j2"
+template:
+  type: "http"
+  url: "https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.2.7/managed-ec2-linux-v2.j2"
 stack_name: "dgutman-htan-new2-ec2"
 sceptre_user_data:
   Distro: "ubuntu"     # (valid values: aws, ubuntu) AMIId must match distro
@@ -37,10 +39,3 @@ parameters:
   JcConnectKey: !ssm "/infra/JcConnectKey"
   JcServiceApiKey: !ssm "/infra/JcServiceApiKey"
   JcSystemsGroupId: !ssm "/infra/JcSystemsGroupId"
-
-# For CI system (do not change)
-hooks:
-  before_launch:
-    - !cmd "curl https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.2.7/managed-ec2-linux-v2.j2 --create-dirs -o templates/remote/managed-ec2-linux-v2.j2"
-  after_create:
-    - !ec2_notify "{{stack_group_config.aws_account_name}} {{stack_group_config.aws_account_email}}"

--- a/config/prod/dgutman-htan-s3.yaml
+++ b/config/prod/dgutman-htan-s3.yaml
@@ -1,6 +1,8 @@
 # Provision a general S3 bucket or a Synapse External Bucket
 # http://docs.synapse.org/articles/custom_storage_location.html
-template_path: "remote/s3-bucket.yaml"
+template:
+  type: "http"
+  url: "https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.2.7/s3-bucket.yaml"
 stack_name: "dgutman-htan-s3"
 parameters:
   # The Sage deparment (Platform, CompOnc, SysBio, Governance, etc..)
@@ -33,10 +35,3 @@ parameters:
   # LifecycleDataTransition: '90'
   # (Optional) Number of days (from creation) when objects are deleted from S3 and LifecycleDataStorageClass, default is 365000
   # LifecycleDataExpiration: '1825'
-
-# For CI system (do not change)
-hooks:
-  before_launch:
-    - !cmd "curl https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.2.7/s3-bucket.yaml --create-dirs -o templates/remote/s3-bucket.yaml"
-  after_create:
-    - !s3_notify "{{stack_group_config.aws_account_name}} {{stack_group_config.aws_account_email}}"

--- a/config/prod/minidream-R-env-pub-instance-ec2.yaml
+++ b/config/prod/minidream-R-env-pub-instance-ec2.yaml
@@ -21,6 +21,3 @@ parameters:
   JcConnectKey: !ssm "/infra/JcConnectKey"
   JcServiceApiKey: !ssm "/infra/JcServiceApiKey"
   JcSystemsGroupId: !ssm "/infra/JcSystemsGroupId"
-hooks:
-  after_create:
-    - !ec2_notify "{{stack_group_config.aws_account_name}} {{stack_group_config.aws_account_email}}"

--- a/config/prod/tom-ncats.yaml
+++ b/config/prod/tom-ncats.yaml
@@ -1,5 +1,7 @@
 # Provision an EC2 instance
-template_path: "remote/managed-ec2-linux-v1.j2"
+template:
+  type: "http"
+  url: "https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.2.7/managed-ec2-linux-v1.j2"
 stack_name: "tom-ncats"
 sceptre_user_data:
   Distro: "aws"     # (valid values: aws, ubuntu) AMIId must match distro
@@ -37,10 +39,3 @@ parameters:
   JcConnectKey: !ssm "/infra/JcConnectKey"
   JcServiceApiKey: !ssm "/infra/JcServiceApiKey"
   JcSystemsGroupId: !ssm "/infra/JcSystemsGroupId"
-
-# For CI system (do not change)
-hooks:
-  before_launch:
-    - !cmd "curl https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.2.7/managed-ec2-linux-v1.j2 --create-dirs -o templates/remote/managed-ec2-linux-v1.j2"
-  after_create:
-    - !ec2_notify "{{stack_group_config.aws_account_name}} {{stack_group_config.aws_account_email}}"

--- a/config/prod/xdoan-clarisse-htan-s3.yaml
+++ b/config/prod/xdoan-clarisse-htan-s3.yaml
@@ -1,6 +1,8 @@
 # Provision a general S3 bucket or a Synapse External Bucket
 # http://docs.synapse.org/articles/custom_storage_location.html
-template_path: "remote/s3-bucket.yaml"
+template:
+  type: "http"
+  url: "https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.2.7/s3-bucket.yaml"
 stack_name: "xdoan-clarisse-htan-s3"
 parameters:
   # The Sage deparment (Platform, CompOnc, SysBio, Governance, etc..)
@@ -34,10 +36,3 @@ parameters:
   # LifecycleDataTransition: '90'
   # (Optional) Number of days (from creation) when objects are deleted from S3 and LifecycleDataStorageClass, default is 365000
   # LifecycleDataExpiration: '1825'
-
-# For CI system (do not change)
-hooks:
-  before_launch:
-    - !cmd "curl https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.2.7/s3-bucket.yaml --create-dirs -o templates/remote/s3-bucket.yaml"
-  after_create:
-    - !s3_notify "{{stack_group_config.aws_account_name}} {{stack_group_config.aws_account_email}}"

--- a/config/prod/xdoan-htan-ec2.yaml
+++ b/config/prod/xdoan-htan-ec2.yaml
@@ -1,5 +1,7 @@
 # Provision an EC2 instance
-template_path: "remote/managed-ec2-linux-v2.j2"
+template:
+  type: "http"
+  url: "https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.2.7/managed-ec2-linux-v2.j2"
 stack_name: "xdoan-htan-ec2"
 sceptre_user_data:
   Distro: "ubuntu"     # (valid values: aws, ubuntu) AMIId must match distro
@@ -37,10 +39,3 @@ parameters:
   JcConnectKey: !ssm "/infra/JcConnectKey"
   JcServiceApiKey: !ssm "/infra/JcServiceApiKey"
   JcSystemsGroupId: !ssm "/infra/JcSystemsGroupId"
-
-# For CI system (do not change)
-hooks:
-  before_launch:
-    - !cmd "curl https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.2.7/managed-ec2-linux-v2.j2 --create-dirs -o templates/remote/managed-ec2-linux-v2.j2"
-  after_create:
-    - !ec2_notify "{{stack_group_config.aws_account_name}} {{stack_group_config.aws_account_email}}"

--- a/config/prod/xdoan-test-s3.yaml
+++ b/config/prod/xdoan-test-s3.yaml
@@ -1,6 +1,8 @@
 # Provision a general S3 bucket or a Synapse External Bucket
 # http://docs.synapse.org/articles/custom_storage_location.html
-template_path: "remote/s3-bucket.yaml"
+template:
+  type: "http"
+  url: "https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.2.7/s3-bucket.yaml"
 stack_name: "xdoan-test-s3"
 parameters:
   # The Sage deparment (Platform, CompOnc, SysBio, Governance, etc..)
@@ -33,10 +35,3 @@ parameters:
   # LifecycleDataTransition: '90'
   # (Optional) Number of days (from creation) when objects are deleted from S3 and LifecycleDataStorageClass, default is 365000
   # LifecycleDataExpiration: '1825'
-
-# For CI system (do not change)
-hooks:
-  before_launch:
-    - !cmd "curl https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/v0.2.7/s3-bucket.yaml --create-dirs -o templates/remote/s3-bucket.yaml"
-  after_create:
-    - !s3_notify "{{stack_group_config.aws_account_name}} {{stack_group_config.aws_account_email}}"


### PR DESCRIPTION
Sceptre supports template handlers[1] to get remote templates so we no
longer need to use hooks.  Convert all hooks to template handler.

[1] https://docs.sceptre-project.org/dev/docs/template_handlers.html
