### PR TITLE
[IT-1531] Use sceptrelint validate stack tags

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,9 +18,13 @@ repos:
     hooks:
     -   id: remove-tabs
 -   repo: https://github.com/sceptre/sceptrelint
-    rev: v1.0.1
+    rev: v1.1.0
     hooks:
     -    id: check-file-names
     -    id: check-stack-names
-    -    id: check-stack-tags
-         args: [--tag=CostCenter]
+    -    id: check-stack-tag-values
+         args: [--tag=CostCenter,
+                --file=https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/master/templates/tags/SageFinancialProgramCodes.json,
+                --file=https://raw.githubusercontent.com/Sage-Bionetworks/aws-infra/master/templates/tags/SageFinancialProgramCodesOther.json,
+                --exclude=Other / 000001
+         ]


### PR DESCRIPTION
Use the new precommit linter check-stack-tags[1] to validate that
the assigned CostCenter tags are valid.

[1] https://github.com/Sceptre/sceptrelint
