### PR TITLE
Move jharker-test to an Ubuntu AMI

### DIFF
--- a/config/prod/jharker-test.yaml
+++ b/config/prod/jharker-test.yaml
@@ -10,7 +10,7 @@ stack_tags:
   CostCenter: "Platform Infrastructure / 990300"
 
 sceptre_user_data:
-  Distro: "aws"     # (valid values: aws, ubuntu) AMIId must match distro
+  Distro: "ubuntu"     # (valid values: aws, ubuntu) AMIId must match distro
   # (Optional) Expose ports to incoming traffic (default is no open ports) (valid range: 1-65535)
   # OpenPorts: ["3838","4151"]
 parameters:
@@ -19,7 +19,7 @@ parameters:
   # Default account settings, leave alone unless you plan to override
   VpcName: "sandcastlevpc"
   KeyName: "sandbox"
-  AMIId: "ami-0cff7528ff583bf9a"      # AWS linux 2 AMI 2.0.20200108 x86_64 HVM gp2
+  AMIId: "ami-052efd3df9dad4825"      # Ubuntu 22.04 LTS
 
   # Settings have default values but can be overriden. Set the below
   # parameters *only* if you want to override the defaults.


### PR DESCRIPTION
I had deployed the stack before adding my ssh key to jump cloud. Attempt to work around a missing ssh key on the instance by changing the underlying AMI.